### PR TITLE
Added actor name and color when they are speaking

### DIFF
--- a/Assets/Prefabs/StandardInclusion.prefab
+++ b/Assets/Prefabs/StandardInclusion.prefab
@@ -607,6 +607,7 @@ Transform:
   - {fileID: 5228303783134667827}
   - {fileID: 5228303784783594413}
   - {fileID: 650829537}
+  - {fileID: 3285783841525555693}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1024,6 +1025,80 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!1 &7228055915782335262
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3285783841525555693}
+  - component: {fileID: 2828194008833542549}
+  - component: {fileID: 3069363973248438169}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3285783841525555693
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7228055915782335262}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5228303783942753771}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2828194008833542549
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7228055915782335262}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!114 &3069363973248438169
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7228055915782335262}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_PointAction: {fileID: 1054132383583890850, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MoveAction: {fileID: 3710738434707379630, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_SubmitAction: {fileID: 2064916234097673511, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_CancelAction: {fileID: -1967631576421560919, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_LeftClickAction: {fileID: 8056856818456041789, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MiddleClickAction: {fileID: 3279352641294131588, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_RightClickAction: {fileID: 3837173908680883260, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ScrollWheelAction: {fileID: 4502412055082496612, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 4754684134866288074, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 1025543830046995696, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
 --- !u!1001 &5228303783516512005
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1223,9 +1298,9 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 37849bb488a16344e8888662757571aa, type: 3}
---- !u!114 &5490628541157029231 stripped
+--- !u!114 &2355926578739761039 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 341159792951127872, guid: 37849bb488a16344e8888662757571aa, type: 3}
+  m_CorrespondingSourceObject: {fileID: 7511797654307280288, guid: 37849bb488a16344e8888662757571aa, type: 3}
   m_PrefabInstance: {fileID: 5228303784605014575}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
@@ -1245,9 +1320,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &2355926578739761039 stripped
+--- !u!114 &5490628541157029231 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7511797654307280288, guid: 37849bb488a16344e8888662757571aa, type: 3}
+  m_CorrespondingSourceObject: {fileID: 341159792951127872, guid: 37849bb488a16344e8888662757571aa, type: 3}
   m_PrefabInstance: {fileID: 5228303784605014575}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}

--- a/Assets/Prefabs/StandardInclusion.prefab
+++ b/Assets/Prefabs/StandardInclusion.prefab
@@ -511,6 +511,21 @@ MonoBehaviour:
   _directorActionDecoder: {fileID: 5228303783986964379}
   _actorDictionary: {fileID: 11400000, guid: 8a614ed376c0c4ab889d18152bd51c7e, type: 2}
   _activeActor: {fileID: 5228303784028554615}
+  _onNewSpeakingActor:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5228303784783594414}
+        m_TargetAssemblyTypeName: AppearingDialogueController, GG-JointJustice
+        m_MethodName: SetActiveSpeaker
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   _onAnimationStarted:
     m_PersistentCalls:
       m_Calls:

--- a/Assets/Scenes/Inky-TestScene.unity
+++ b/Assets/Scenes/Inky-TestScene.unity
@@ -294,6 +294,46 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3245558184056835669, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: m_Color.b
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3245558184056835669, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: m_Color.g
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3245558184056835669, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303783822522784, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onNewSpeakingActor.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303783822522784, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onNewSpeakingActor.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303783822522784, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onNewSpeakingActor.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 5228303782951346617}
+    - target: {fileID: 5228303783822522784, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onNewSpeakingActor.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303783822522784, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onNewSpeakingActor.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SetActiveSpeaker
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303783822522784, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onNewSpeakingActor.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: AppearingDialogueController, GG-JointJustice
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303783822522784, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onNewSpeakingActor.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 5228303783942753770, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
       propertyPath: m_Name
       value: StandardInclusion
@@ -344,3 +384,14 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+--- !u!114 &5228303782951346617 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+  m_PrefabInstance: {fileID: 5228303782951346616}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b31ee0231f45e143a89b3235cac7439, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scenes/Inky-TestScene.unity
+++ b/Assets/Scenes/Inky-TestScene.unity
@@ -294,46 +294,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 3245558184056835669, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
-      propertyPath: m_Color.b
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3245558184056835669, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
-      propertyPath: m_Color.g
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3245558184056835669, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
-      propertyPath: m_Color.r
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5228303783822522784, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
-      propertyPath: _onNewSpeakingActor.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5228303783822522784, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
-      propertyPath: _onNewSpeakingActor.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5228303783822522784, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
-      propertyPath: _onNewSpeakingActor.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 5228303782951346617}
-    - target: {fileID: 5228303783822522784, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
-      propertyPath: _onNewSpeakingActor.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 5228303783822522784, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
-      propertyPath: _onNewSpeakingActor.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: SetActiveSpeaker
-      objectReference: {fileID: 0}
-    - target: {fileID: 5228303783822522784, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
-      propertyPath: _onNewSpeakingActor.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
-      value: AppearingDialogueController, GG-JointJustice
-      objectReference: {fileID: 0}
-    - target: {fileID: 5228303783822522784, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
-      propertyPath: _onNewSpeakingActor.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
     - target: {fileID: 5228303783942753770, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
       propertyPath: m_Name
       value: StandardInclusion
@@ -384,14 +344,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
---- !u!114 &5228303782951346617 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
-  m_PrefabInstance: {fileID: 5228303782951346616}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8b31ee0231f45e143a89b3235cac7439, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/Assets/ScriptableObjects/Actors/Arin.asset
+++ b/Assets/ScriptableObjects/Actors/Arin.asset
@@ -14,5 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <Profile>k__BackingField: {fileID: 21300000, guid: 04b0eedfbca19d84cb4db63538ba6241, type: 3}
   <DefaultSprite>k__BackingField: {fileID: 9095853184155359625, guid: cbba2ad53e09d3349a685ddc35e8067b, type: 3}
+  <DisplayName>k__BackingField: Arin
+  <DisplayColor>k__BackingField: {r: 0.567169, g: 0, b: 0.8301887, a: 1}
   <Bio>k__BackingField: 
   <AnimatorController>k__BackingField: {fileID: 9100000, guid: 0c3d8f1233f3a49e9a3f32fab7e316af, type: 2}

--- a/Assets/ScriptableObjects/Actors/Dan.asset
+++ b/Assets/ScriptableObjects/Actors/Dan.asset
@@ -14,5 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <Profile>k__BackingField: {fileID: 21300000, guid: ed609b8fe4846d14bad6bb5f2b3677e4, type: 3}
   <DefaultSprite>k__BackingField: {fileID: 9095853184155359625, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+  <DisplayName>k__BackingField: Dan
+  <DisplayColor>k__BackingField: {r: 0, g: 0.253304, b: 1, a: 1}
   <Bio>k__BackingField: 
   <AnimatorController>k__BackingField: {fileID: 9100000, guid: 61d75a6dad4224b6f8e9591f88230da3, type: 2}

--- a/Assets/ScriptableObjects/Actors/Jory.asset
+++ b/Assets/ScriptableObjects/Actors/Jory.asset
@@ -14,5 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <Profile>k__BackingField: {fileID: 0}
   <DefaultSprite>k__BackingField: {fileID: 9095853184155359625, guid: 26a9c8485eebf984398ac2094b0fcdc7, type: 3}
+  <DisplayName>k__BackingField: Jory
+  <DisplayColor>k__BackingField: {r: 0.09613409, g: 0.5660378, b: 0, a: 1}
   <Bio>k__BackingField: 
   <AnimatorController>k__BackingField: {fileID: 9100000, guid: cfd482816b6674280a326432f76ac73b, type: 2}

--- a/Assets/ScriptableObjects/Actors/Ross.asset
+++ b/Assets/ScriptableObjects/Actors/Ross.asset
@@ -14,5 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <Profile>k__BackingField: {fileID: 21300000, guid: 54752dc9ae7593c4f8516d411bb6ffdd, type: 3}
   <DefaultSprite>k__BackingField: {fileID: 0}
+  <DisplayName>k__BackingField: Ross
+  <DisplayColor>k__BackingField: {r: 1, g: 0.9813726, b: 0, a: 1}
   <Bio>k__BackingField: 
   <AnimatorController>k__BackingField: {fileID: 9100000, guid: fe3fd78ce64a446c0bb135d09a8a7fb0, type: 2}

--- a/Assets/Scripts/Actor/ActorController.cs
+++ b/Assets/Scripts/Actor/ActorController.cs
@@ -12,11 +12,15 @@ public class ActorController : MonoBehaviour, IActorController
     [Tooltip("Drag an ActorDictionary instance here, containing every required character")]
     [SerializeField] private ActorDictionary _actorDictionary;
 
+    
+
     //TODO serialized for debug purposes. Should be set by scene controller.
     [SerializeField] private Actor _activeActor;
 
+    [SerializeField] private UnityEvent<ActorData> _onNewSpeakingActor;
     [SerializeField] private UnityEvent _onAnimationStarted;
     [SerializeField] private UnityEvent _onAnimationComplete;
+
 
     public bool Animating { get; set; }
 
@@ -104,7 +108,14 @@ public class ActorController : MonoBehaviour, IActorController
     /// <param name="actor">Target actor. This gets the correct name and colour from the list of existing actors.</param>
     public void SetActiveSpeaker(string actor)
     {
-        Debug.LogWarning("SetActiveSpeaker not implemented");
+        try
+        {
+            _onNewSpeakingActor.Invoke(_actorDictionary.Actors[actor]);
+        }
+        catch (KeyNotFoundException exception)
+        {
+            Debug.Log($"{exception.GetType().Name}: Actor was not found in actor dictionary");
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/Actor/ActorData.cs
+++ b/Assets/Scripts/Actor/ActorData.cs
@@ -9,6 +9,12 @@ public class ActorData : ScriptableObject
     
     [field: SerializeField, Tooltip("The sprite that should be displayed if an incompatible animation is played.")]
     public Sprite DefaultSprite { get; private set; }
+
+    [field: SerializeField, Tooltip("Name displayed when referring to this actor or when they are speaking.")]
+    public string DisplayName { get; private set; }
+
+    [field: SerializeField, Tooltip("Color for the background of the name when speaking.")]
+    public Color DisplayColor { get; private set; }
     
     [field: SerializeField, TextArea, Tooltip("A description of the actor that will appear in the profiles menu.")]
     public string Bio { get; private set; }

--- a/Assets/Scripts/UI/AppearingDialogueController.cs
+++ b/Assets/Scripts/UI/AppearingDialogueController.cs
@@ -500,6 +500,12 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
         _autoSkipDialog = skip;
     }
 
+    public void SetActiveSpeaker(ActorData actor)
+    {
+        ChangeSpeakerName(actor.DisplayName);
+        ChangeNameBGColor(actor.DisplayColor);
+    }
+
     ///<summary>
     ///Changes the name of the speaker.
     ///</summary>

--- a/Assets/Scripts/UI/AppearingDialogueController.cs
+++ b/Assets/Scripts/UI/AppearingDialogueController.cs
@@ -500,6 +500,10 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
         _autoSkipDialog = skip;
     }
 
+    /// <summary>
+    /// Sets the speaker name and bg color based on provided actor data.
+    /// </summary>
+    /// <param name="actor">Actor data to base the changes on.</param>
     public void SetActiveSpeaker(ActorData actor)
     {
         ChangeSpeakerName(actor.DisplayName);


### PR DESCRIPTION
## Summary
Actor data now includes shown name and name background color (can be easily changed) which are shown when they are speaking. The data is gotten in the actor controller because it has the actor list and then pushed outwards using an event and caught by the DissapearingDialogueController

## Before/after screenshots and/or animated gif

![NameColorChange](https://user-images.githubusercontent.com/5979264/131741320-21cb87be-582e-4454-a895-fd4bbe981dce.gif)


## Testing instructions
Open inky test scene and press play. Use x on the keyboard to advance

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[x]` Changes UI
- `[x]` Introduces new feature
- `[ ]` Removes existing feature
- `[ ]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->
