### PR TITLE
Remove automated test execution as part of build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,13 +46,6 @@ jobs:
         with:
           name: ${{ steps.getManualLicenseFile.outputs.filePath }}
           path: ${{ steps.getManualLicenseFile.outputs.filePath }}
-
-  unityTest:
-    name: Run PlayMode and EditorMode tests for Unity project
-    needs: [checkLicense]
-    if: needs.checkLicense.outputs.is_unity_license_set == 'true'
-    runs-on: ubuntu-latest
-    steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -96,7 +89,7 @@ jobs:
 
   unityBuild:
     name: Build for ${{ matrix.targetPlatform.outputName }}
-    needs: [checkLicense, unityTest]
+    needs: [checkLicense]
     if: needs.checkLicense.outputs.is_unity_license_set == 'true'
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Summary
<!--- Describe the change below, including rationale and design decisions -->
Remove automated testing step from build pipeline to resolve 2 hour timeout.
The tests themselves can still be run locally.

## Before/after screenshots and/or animated gif
<!--- Skip this if not applicable -->
Top: before  
Bottom: after
![image](https://user-images.githubusercontent.com/1689033/132856578-7ca816cc-d995-444c-9226-622c36939df6.png)

## Testing instructions
<!--- What steps can be taken to manually verify the changes? -->
Run [the build pipeline](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/actions/workflows/build.yml) on this branch.

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[x]` Removes existing feature
  - Automated PlayMode and EditMode execution
- `[ ]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->
