### PR TITLE
Feature/43 Writer can stop music

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,8 @@ ehthumbs.db
 
 #Unit Test Scenes
 Assets/InitTestScene*
+
+# Editor Rish Presence (for Discord)
+Assets/ERP
+Assets/ERP.meta
+.erp

--- a/Assets/Resources/InkDialogueScripts/AudioTest.ink
+++ b/Assets/Resources/InkDialogueScripts/AudioTest.ink
@@ -1,0 +1,12 @@
+﻿&SCENE:TMPH_Defense
+&PLAYSONG:aKissFromARose
+&ACTOR:Dan
+&SPEAK:Dan
+This is some rad music!
+
+&STOP_SONG
+&SPEAK:Tutorial_Boy
+SILENCE!
+
+&SPEAK:Dan
+...aww, it stopped.

--- a/Assets/Resources/InkDialogueScripts/AudioTest.ink.meta
+++ b/Assets/Resources/InkDialogueScripts/AudioTest.ink.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 39a5548f400e6b9418aceea1d91800cd
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/InkDialogueScripts/AudioTest.json
+++ b/Assets/Resources/InkDialogueScripts/AudioTest.json
@@ -1,0 +1,1 @@
+﻿{"inkVersion":20,"root":[["^&SCENE:TMPH_Defense","\n","^&PLAYSONG:aKissFromARose","\n","^&ACTOR:Dan","\n","^&SPEAK:Dan","\n","^This is some rad music!","\n","^&STOP_SONG","\n","^&SPEAK:Tutorial_Boy","\n","^SILENCE!","\n","^&SPEAK:Dan","\n","^...aww, it stopped.","\n",["done",{"#f":5,"#n":"g-0"}],null],"done",{"#f":1}],"listDefs":{}}

--- a/Assets/Resources/InkDialogueScripts/AudioTest.json.meta
+++ b/Assets/Resources/InkDialogueScripts/AudioTest.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6ff407202ea2b1b4c9fba7e6b8802ba5
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/AudioController/AudioController.cs
+++ b/Assets/Scripts/AudioController/AudioController.cs
@@ -120,13 +120,10 @@ public class AudioController : MonoBehaviour, IAudioController
     /// </summary>
     public void StopSong()
     {
-        _isTransitioningMusicTracks = true;
         if (_musicAudioSource != null)
         {
             _musicAudioSource.Stop();
         }
-
-        _isTransitioningMusicTracks = false;
     }
 
     /// <summary>

--- a/Assets/Scripts/AudioController/AudioController.cs
+++ b/Assets/Scripts/AudioController/AudioController.cs
@@ -116,6 +116,20 @@ public class AudioController : MonoBehaviour, IAudioController
     }
 
     /// <summary>
+    /// If music is currently playing, stop it!
+    /// </summary>
+    public void StopSong()
+    {
+        _isTransitioningMusicTracks = true;
+        if (_musicAudioSource != null)
+        {
+            _musicAudioSource.Stop();
+        }
+
+        _isTransitioningMusicTracks = false;
+    }
+
+    /// <summary>
     /// Are we playing music?
     /// </summary>
     /// <returns>True if we're playing a music track with a volume above zero</returns>

--- a/Assets/Scripts/Interfaces/IAudioController.cs
+++ b/Assets/Scripts/Interfaces/IAudioController.cs
@@ -2,4 +2,5 @@ public interface IAudioController
 {
     void PlaySFX(string SFX);
     void PlaySong(string songName);
+    void StopSong();
 }

--- a/Assets/Scripts/TextDecoder/DirectorActionDecoder.cs
+++ b/Assets/Scripts/TextDecoder/DirectorActionDecoder.cs
@@ -51,6 +51,7 @@ public class DirectorActionDecoder : MonoBehaviour
             //Audio controller
             case "PLAYSFX": PlaySFX(parameters); break;
             case "PLAYSONG": SetBGMusic(parameters); break;
+            case "STOP_SONG": StopSong(); break;
             //Scene controller
             case "FADE_OUT": FadeOutScene(parameters); break;
             case "FADE_IN": FadeInScene(parameters); break;
@@ -398,6 +399,18 @@ public class DirectorActionDecoder : MonoBehaviour
             return;
 
         _audioController.PlaySong(songName);
+        _onActionDone.Invoke();
+    }
+
+    /// <summary>
+    /// If music is currently playing, stop it!
+    /// </summary>
+    void StopSong()
+    {
+        if (!HasAudioController())
+            return;
+
+        _audioController.StopSong();
         _onActionDone.Invoke();
     }
     #endregion


### PR DESCRIPTION
## Summary
<!--- Describe the change below, including rationale and design decisions -->
Implements the `STOP_SONG` command, which allows writers to stop a song within an ink script.

## Testing instructions
<!--- What steps can be taken to manually verify the changes? -->
- Run `Inky-TestScene` with the new `AudioTest` ink script in the DialogueController

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- [x] Introduces new feature
- `[ ]` Removes existing feature
- [x] Has associated resource: https://github.com/Studio-Lovelies/GG-JointJustice-Unity/issues/43
  <!--- Include any project card, github issue, etc. associated with this PR -->
