### PR TITLE
Feature/54 speech sfx on nth letter

### DIFF
--- a/Assets/Scenes/Inky-TestScene.unity
+++ b/Assets/Scenes/Inky-TestScene.unity
@@ -270,6 +270,17 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8092316712924599042, guid: 6a76445d659e2db4baf7ee7ff4a2133c, type: 3}
   m_PrefabInstance: {fileID: 8092316712680511531}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1244615159 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5766951243316258182, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+  m_PrefabInstance: {fileID: 5228303782951346616}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7c1588c060bf994aa9f9fed3449e1e4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1381699178 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8239092869838533241, guid: 6a76445d659e2db4baf7ee7ff4a2133c, type: 3}
@@ -464,6 +475,58 @@ PrefabInstance:
     - target: {fileID: 5228303783942753771, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _lettersBeforeSpeechSFX
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _maxLettersBeforeSpeechSFX
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onPlaySpeech.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onLetterAppear.m_PersistentCalls.m_Calls.Array.size
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onPlaySpeech.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onLetterAppear.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onPlaySpeech.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1244615159}
+    - target: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onPlaySpeech.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onPlaySpeech.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: PlaySFX
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onLetterAppear.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onPlaySpeech.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: AudioController, GG-JointJustice
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onPlaySpeech.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
+      value: maleTalk
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _onPlaySpeech.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 5228303784977925677, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
       propertyPath: _sceneList

--- a/Assets/Scenes/Inky-TestScene.unity
+++ b/Assets/Scenes/Inky-TestScene.unity
@@ -485,6 +485,14 @@ PrefabInstance:
       value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _percentageSpedUpSpeechSFX
+      value: 80
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _lettersBeforeSpedUpSpeechSFX
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5228303784783594414, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
       propertyPath: _onPlaySpeech.m_PersistentCalls.m_Calls.Array.size
       value: 1
       objectReference: {fileID: 0}

--- a/Assets/Scripts/UI/AppearingDialogueController.cs
+++ b/Assets/Scripts/UI/AppearingDialogueController.cs
@@ -35,6 +35,9 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
     [SerializeField, Tooltip("Number of letters to be displayed before playing a speech SFX")]
     private int _lettersBeforeSpeechSFX = 4;
 
+    [SerializeField, Tooltip("Percentage of the speed before playing a speech SFX when text is sped up")]
+    private float _percentageSpedUpSpeechSFX = 75;
+
     [Header("Events")]
     [SerializeField, Tooltip("Events that should happen before the dialog start.")]
     private UnityEvent _dialogueStartEvent = new UnityEvent();
@@ -272,7 +275,7 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
 
         if (_speedupText)
         {
-            if (_currentLetterCounter >= _lettersBeforeSpeechSFX * (_speedMultiplierFromPlayerInput * 0.80))
+            if (_currentLetterCounter >= _lettersBeforeSpeechSFX + (_lettersBeforeSpeechSFX / (_percentageSpedUpSpeechSFX / 100)))
             {
                 _onPlaySpeech.Invoke();
                 _currentLetterCounter = 0;

--- a/Assets/Scripts/UI/AppearingDialogueController.cs
+++ b/Assets/Scripts/UI/AppearingDialogueController.cs
@@ -272,7 +272,7 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
 
         if (_speedupText)
         {
-            if (_currentLetterCounter >= _lettersBeforeSpeechSFX * (_speedMultiplierFromPlayerInput * 0.75))
+            if (_currentLetterCounter >= _lettersBeforeSpeechSFX * (_speedMultiplierFromPlayerInput * 0.80))
             {
                 _onPlaySpeech.Invoke();
                 _currentLetterCounter = 0;

--- a/Assets/Scripts/UI/AppearingDialogueController.cs
+++ b/Assets/Scripts/UI/AppearingDialogueController.cs
@@ -7,6 +7,7 @@ using TMPro;
 using UnityEngine.Events;
 using UnityEngine.UI;
 
+
 public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueController
 {
     [Header("Basic Values")]
@@ -29,13 +30,10 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
     private float _defaultPunctuationAppearTime = 0.02f;
     [SerializeField, Tooltip("When player is giving correct input to the game, how much faster should the game go.")]
     private float _speedMultiplierFromPlayerInput = 2;
-
     [SerializeField, Tooltip("ActorData that is used to hide the spoken actor.")]
     private ActorData _actorDataHiddenActor;
-
     [SerializeField, Tooltip("Number of letters to be displayed before playing a speech SFX")]
     private int _lettersBeforeSpeechSFX = 4;
-
     [SerializeField, Tooltip("Percentage of the speed before playing a speech SFX when text is sped up")]
     private float _percentageSpedUpSpeechSFX = 75;
 
@@ -44,13 +42,10 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
     private UnityEvent _dialogueStartEvent = new UnityEvent();
     [SerializeField, Tooltip("Events that should happen after completing a dialog.")]
     private UnityEvent _dialogueEndEvent = new UnityEvent();
-
     [SerializeField, Tooltip("Event is invoked every time letter appears")]
     private UnityEvent _onLetterAppear = new UnityEvent();
-
     [SerializeField, Tooltip("Event is invoked every time a speech SFX is to be played")]
     private UnityEvent _onPlaySpeech;
-
     [SerializeField, Tooltip("Event is invoked when dialog ends while autoskip is still true. Should be made to start the next dialog immediatly")]
     private UnityEvent _onAutoSkip = new UnityEvent();
     private string _currentDialog = "";

--- a/Assets/Scripts/UI/AppearingDialogueController.cs
+++ b/Assets/Scripts/UI/AppearingDialogueController.cs
@@ -250,7 +250,10 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
     {
         _timer = 0;
 
-        if (_currentDialog.IndexOf(">") != -1) _currentDialog = _currentDialog.Substring(_currentDialog.IndexOf(">"));
+        if (_currentDialog.IndexOf(">") != -1)
+        {
+            _currentDialog = _currentDialog.Substring(_currentDialog.IndexOf(">") + 1);
+        }
 
         //Increase the maxVisibleCharacters to show the next letter.
         _controlledText.maxVisibleCharacters = _currentLetterNum;
@@ -282,6 +285,7 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
 
         if (_currentLetterCounter >= maxLetters)
         {
+            Debug.Log("Play sound");
             _onPlaySpeech.Invoke();
             _currentLetterCounter = 0;
         }

--- a/Assets/Scripts/UI/AppearingDialogueController.cs
+++ b/Assets/Scripts/UI/AppearingDialogueController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
@@ -249,6 +250,8 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
     {
         _timer = 0;
 
+        if (_currentDialog.IndexOf(">") != -1) _currentDialog = _currentDialog.Substring(_currentDialog.IndexOf(">"));
+
         //Increase the maxVisibleCharacters to show the next letter.
         _controlledText.maxVisibleCharacters = _currentLetterNum;
         _onLetterAppear.Invoke();
@@ -264,30 +267,23 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
             isPunctuation = _currentDialog[_currentLetterNum - 1] == ',' || _currentDialog[_currentLetterNum - 1] == '.' || _currentDialog[_currentLetterNum - 1] == '?' || _currentDialog[_currentLetterNum - 1] == '!';
         }
 
-        if (!isPunctuation)
+        _currentLetterCounter = isPunctuation ? _currentLetterCounter = 0 : _currentLetterCounter = _currentLetterCounter + 1;
+
+        /*if (!isPunctuation)
         {
             _currentLetterCounter++;
         }
         else
         {
             _currentLetterCounter = 0;
-        }
+        }*/
 
-        if (_speedupText)
+        int maxLetters = _speedupText ? (int)Math.Round(_lettersBeforeSpeechSFX + (_lettersBeforeSpeechSFX / (_percentageSpedUpSpeechSFX / 100))) : _lettersBeforeSpeechSFX;
+
+        if (_currentLetterCounter >= maxLetters)
         {
-            if (_currentLetterCounter >= _lettersBeforeSpeechSFX + (_lettersBeforeSpeechSFX / (_percentageSpedUpSpeechSFX / 100)))
-            {
-                _onPlaySpeech.Invoke();
-                _currentLetterCounter = 0;
-            }
-        }
-        else
-        {
-           if (_currentLetterCounter >= _lettersBeforeSpeechSFX)
-            {
-                _onPlaySpeech.Invoke();
-                _currentLetterCounter = 0;
-            }
+            _onPlaySpeech.Invoke();
+            _currentLetterCounter = 0;
         }
 
         //If the end of dialog is reached, make appropriate measures.


### PR DESCRIPTION
## Summary
Added speech SFX logic for every nth letter, every 4th by default with 75% speed when player speeds up dialogue (with respective SerializedFields). Also added a `onPlaySpeech` UnityEvent to trigger the .wav file. For now, it only plays "maleTalk.wav" since it's a constant given in the Unity editor. Will automate speech gender in another PR.

## Testing instructions
Play the game and launch a dialogue lmao

## Additional information
- `[X]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[ ]` Has associated resource:
closes #54 