### PR TITLE
Generalize enum parsing inside ActionDecoder and add respective tests

### DIFF
--- a/Assets/Tests/EditModeTests/ActionDecoderEnum.cs
+++ b/Assets/Tests/EditModeTests/ActionDecoderEnum.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using Moq;
+using TextDecoder.Parser;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class ActionDecoderEnumTests
+{
+    /// <summary>
+    /// Helper method to create a fully mocked ActionDecoder
+    /// </summary>
+    /// <returns>A fully mocked ActionDecoder</returns>
+    private static ActionDecoder CreateMockedActionDecoder()
+    {
+        return new ActionDecoder()
+        {
+            ActorController = new Moq.Mock<IActorController>().Object,
+            AppearingDialogueController = new Moq.Mock<IAppearingDialogueController>().Object,
+            AudioController = new Moq.Mock<IAudioController>().Object,
+            EvidenceController = new Moq.Mock<IEvidenceController>().Object,
+            SceneController = new Moq.Mock<ISceneController>().Object,
+        };
+    }
+
+    [Test]
+    public void ParseActionLineWithValidEnumValue()
+    {
+        ActionDecoder decoder = CreateMockedActionDecoder();
+        Mock<ISceneController> sceneControllerMock = new Moq.Mock<ISceneController>();
+        sceneControllerMock.Setup(controller => controller.ShowItem("a", ItemDisplayPosition.Left));
+        decoder.SceneController = sceneControllerMock.Object;
+
+        const string lineToParse = " &SHOW_ITEM:a,Left \n\n\n";
+        const string logMessage = "Attempting to parse:\n" + lineToParse;
+        Debug.Log(logMessage);
+        Assert.DoesNotThrow(() => { decoder.OnNewActionLine(lineToParse); });
+
+        LogAssert.Expect(LogType.Log, logMessage);
+        LogAssert.NoUnexpectedReceived();
+
+        sceneControllerMock.Verify(controller => controller.ShowItem("a", ItemDisplayPosition.Left), Times.Once);
+    }
+
+    [Test]
+    public void ParseActionLineWithInvalidEnumValue()
+    {
+        ActionDecoder decoder = CreateMockedActionDecoder();
+        Mock<ISceneController> sceneControllerMock = new Moq.Mock<ISceneController>();
+        sceneControllerMock.Setup(controller => controller.ShowItem("a", ItemDisplayPosition.Left));
+        decoder.SceneController = sceneControllerMock.Object;
+
+        const string lineToParse = " &SHOW_ITEM:a,Lleft \n\n\n";
+        const string logMessage = "Attempting to parse:\n" + lineToParse;
+        Debug.Log(logMessage);
+        Assert.Throws<ScriptParsingException>(() => { decoder.OnNewActionLine(lineToParse); }, "'Lleft' is incorrect as parameter #2 (itemPos) for action 'SHOW_ITEM': Cannot convert 'Lleft' into an ItemDisplayPosition (valid values include: 'Left, Right, Middle')");
+
+        LogAssert.Expect(LogType.Log, logMessage);
+        LogAssert.NoUnexpectedReceived();
+
+        sceneControllerMock.Verify(controller => controller.ShowItem("a", ItemDisplayPosition.Left), Times.Never);
+    }
+
+}

--- a/Assets/Tests/EditModeTests/ActionDecoderEnum.cs.meta
+++ b/Assets/Tests/EditModeTests/ActionDecoderEnum.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8204adc9f037b4543a1fa026baf848b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
This change removes the need to add explicit `Parser`s for each enum type that should be supported as parameter type inside the `ActionDecoder`.

## Before/after screenshots and/or animated gif
Before this change, each instance of an `enum` that was available as value type inside our narrative scripts, required an extra class which derives from `Parser<T>`. For example, [ItemDisplayPositionParser](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/blob/4b6db7a79046064a95806d209c104c1b86cd755e/Assets/Scripts/TextDecoder/Parser/ItemDisplayPositionParser.cs#L1).

After this change, [`enum`s are handled generically](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/blob/4b6db7a79046064a95806d209c104c1b86cd755e/Assets/Scripts/TextDecoder/ActionDecoder.cs#L74-L92): If a parameter type derives from the type `System.Enum`, it's attempted to be cast in a generic way.

## Testing instructions
1. Create a new enum type
2. Attempt to add a new "event" inside the ActionDecoder with that new enum as parameter
3. Create a narrative script that uses a value of that enum type
4. Notice the script being executed successfully
5. Deliberately add a typo to the value inside your narrative script (I.e. change `Left` to `LLeft`)
6. Notice the script failing to execute and a human-readable message including all possible values being displayed inside the `Console` window in Unity

Two test cases have also been added:
* `ActionDecoderEnumTests.ParseActionLineWithValidEnumValue`
* `ActionDecoderEnumTests.ParseActionLineWithInvalidEnumValue`

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[x]` Has associated resource: 
  - https://github.com/Studio-Lovelies/GG-JointJustice-Unity/pull/93#discussion_r762464924
  <!--- Include any project card, github issue, etc. associated with this PR -->
