### PR TITLE
Only play dialogue chirps on the nth letter

### DIFF
--- a/unity-ggjj/Assets/Scenes/TestScenes/Inky -TestScene.unity
+++ b/unity-ggjj/Assets/Scenes/TestScenes/Inky -TestScene.unity
@@ -204,6 +204,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.x
       value: -25
       objectReference: {fileID: 0}
+    - target: {fileID: 3677055759813406900, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
+      propertyPath: _chirpEveryNthLetter
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 3697150471741588061, guid: ef7dd0dd7a380264d90181b3a106c435, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0

--- a/unity-ggjj/Assets/Scripts/UI/AppearingDialogueController.cs
+++ b/unity-ggjj/Assets/Scripts/UI/AppearingDialogueController.cs
@@ -37,6 +37,10 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
     [Tooltip("Add an AudioClip for the default dialogue chirp here")]
     [SerializeField] private AudioClip _defaultDialogueChirpSfx;
     
+    [Tooltip("Specify how often a chirp should play here")]
+    [SerializeField] private int _chirpEveryNthLetter = 1;
+
+    
     [field:Header("Events")]
     [field:SerializeField] public UnityEvent OnLineEnd { get; private set; }
     [SerializeField] private UnityEvent _onAutoSkip;
@@ -44,6 +48,7 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
 
     private TMP_TextInfo _textInfo;
     private Coroutine _printCoroutine;
+    private int _chirpIndex;
 
     public float SpeedMultiplier { get; set; } = 1;
     public bool SkippingDisabled { get; set; }
@@ -120,7 +125,7 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
             _textBox.maxVisibleCharacters++;
             _onLetterAppear.Invoke();
             var currentCharacterInfo = _textInfo.characterInfo[_textBox.maxVisibleCharacters - 1];
-            PlayDialogueChirp(_namebox.CurrentActorDialogueChirp, currentCharacterInfo);
+            TryPlayDialogueChirp(_namebox.CurrentActorDialogueChirp, currentCharacterInfo);
             yield return new WaitForSeconds(GetDelay(currentCharacterInfo));
         }
         OnLineEnd.Invoke();
@@ -134,14 +139,18 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
     }
 
     /// <summary>
-    /// Play dialogue chirp sound effect for current actor, if it exists
+    /// Increment the chirp index and try to play dialogue chirp sound effect for current actor
+    /// - If no chirp is specified, we will play the default chirp.
+    /// - If the chirp index is not evenly divided by `_chirpEveryNthLetter` then we play no sound.
+    /// - If the character is treated as punctuation, the chirp index is reset
     /// </summary>
     /// <param name="currentActorChirp">Speaker actor's dialogue chirp</param>
     /// <param name="characterInfo">CharacterInfo for the character to play chirp on (skipped if punctuation or ignored)</param>
-    private void PlayDialogueChirp(AudioClip currentActorChirp, TMP_CharacterInfo characterInfo)
+    private void TryPlayDialogueChirp(AudioClip currentActorChirp, TMP_CharacterInfo characterInfo)
     {
         if (CharShouldBeTreatedAsPunctuation(characterInfo))
         {
+            _chirpIndex = 0;
             return;
         }
         
@@ -150,7 +159,13 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
         {
             resultChirp = _defaultDialogueChirpSfx;
         }
-        _audioController.PlaySfx(resultChirp);
+        
+        if (_chirpIndex % _chirpEveryNthLetter == 0)
+        {
+            _audioController.PlaySfx(resultChirp);
+        }
+        
+        _chirpIndex++;
     }
 
     /// <summary>

--- a/unity-ggjj/Assets/Scripts/UI/AppearingDialogueController.cs
+++ b/unity-ggjj/Assets/Scripts/UI/AppearingDialogueController.cs
@@ -37,6 +37,7 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
     [Tooltip("Add an AudioClip for the default dialogue chirp here")]
     [SerializeField] private AudioClip _defaultDialogueChirpSfx;
     
+    [Range(1, 10)]
     [Tooltip("Specify how often a chirp should play here")]
     [SerializeField] private int _chirpEveryNthLetter = 1;
 


### PR DESCRIPTION
## Summary
Normally when the dialogue text crawl shows up the chirps look like this.

(dots represent chirps, underscores are silence)

`Hello I am Arin`
`....._._.._....`

which makes my ears bleed.

Now it's more like:

`Hello I am Arin`
`.__.__._.__.__.` (where n=3)

## Testing instructions
Play the game and see if it sounds right at different N values. If you set N to zero the game crashes because we attempt a divide (modulus actually) by zero.

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[x]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[x]` Has associated resource: 
#54 
