### PR TITLE
Correct list of valid "SceneAssetNames" inside auto-generated documentation

### DIFF
--- a/docs/constants.md
+++ b/docs/constants.md
@@ -117,9 +117,18 @@
   - TutorialBoysTragicallyGenericReminiscence
 
 ## SceneAssetName
-  - BaseScene
-  - MainMenu
-  - Splash
+  - Anime
+  - TMPHAssistant
+  - TMPHCourt
+  - TMPHDefense
+  - TMPHGalaxyBrain
+  - TMPHJudge
+  - TMPHLobby
+  - TMPHProsecution
+  - TMPHRoss
+  - TMPHRossWithDinos
+  - TMPHWideShot
+  - TMPHWitness
 
 ## FullscreenAnimationAssetName
   - BadBoy

--- a/unity-ggjj/Assets/Scripts/TextDecoder/ActionDecoder.cs
+++ b/unity-ggjj/Assets/Scripts/TextDecoder/ActionDecoder.cs
@@ -372,7 +372,7 @@ public class ActionDecoder
     }
 
     /// <summary>Sets the scene. If an actor was already attached to target scene, it will show up as well.</summary>
-    /// <param name="sceneName" validFiles="Assets/Scenes/*.unity">Name of a scene</param>
+    /// <param name="sceneName" validFiles="Assets/Resources/BGScenes/*.prefab">Name of a scene</param>
     /// <example>&amp;SCENE:TMPH_Court</example>
     /// <category>Scene</category>
     private void SCENE(SceneAssetName sceneName)


### PR DESCRIPTION
## Summary
Resolves #193.

## Before/after screenshots and/or animated gif

- [before](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/blob/develop/docs/constants.md#sceneassetname)
- [after](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/blob/bug/193-scene-constants/docs/constants.md#sceneassetname)

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[x]` Has associated resource: 
  - closes #193 
