### PR TITLE
Prevent code coverage upload from occurring for canceled builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload XML report to Codecov
         uses: codecov/codecov-action@v2
-        if: always()
+        if: ${{ failure() || success() }}
         with:
           name: EditMode+PlayMode
           flags: automated
@@ -112,7 +112,7 @@ jobs:
 
       - name: Store test artifacts
         uses: actions/upload-artifact@v2
-        if: always()
+        if: ${{ failure() || success() }}
         with:
           name: Test results
           path: artifacts


### PR DESCRIPTION
## Summary
This PR prevents incomplete code coverage reports from being uploaded to Codecov.io.

## Before/after screenshots and/or animated gif
![image](https://user-images.githubusercontent.com/1689033/154561656-30f4f173-d5b4-4dd0-8c3f-a79a29580f94.png)

Currently code coverage reports are uploaded after the tests have run, even if a previous task has failed **or has been cancelled** (since having any test fail will fail the entire "run the tests" task).
Additionally, if we have a build running and a new commit is added to the same branch, all builds for that branch get cancelled, so we don't have to wait for outdated builds to finish (if either the doc generator ran or someone pushes multiple times with a few minutes passing each time), resulting in code coverage for a (potentially) incomplete build being uploaded.

As an example, [this report was generated](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/pull/194#issuecomment-1042524818) as the tests for 4155169656a880488a9cab5e1b21cc06644b28d1 were running while f8062e085f0f7d93176ba17d626b69105204b175 got added. This cancels the build and tests but since coverage reports are always uploaded, the coverage report is incomplete.

This PR limits code coverage uploads to successful and failed builds (and prevents it from occurring for cancelled builds).

## Testing instructions
1. Run a game build for this PR
2. Cancel the build around 6 minutes into `Run PlayMode and EditorMode tests for Unity project`
3. Notice the `Upload XML report to Codecov` task no longer being executed

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[ ]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->
