### PR TITLE
Split code coverage report into EditMode, PlayMode Scripts and PlayMode Scenes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,7 @@ jobs:
           projectPath: unity-ggjj/
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           testMode: EditMode
+          checkName: Test Results - EditMode
           customParameters: -debugCodeOptimization -enableCodeCoverage -coverageResultsPath ./coverage-results -coverageOptions generateAdditionalMetrics;assemblyFilters:+GG-JointJustice
 
       - name: Upload XML report to Codecov
@@ -118,7 +119,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: ${{ failure() || success() }}
         with:
-          name: Test results
+          name: Test Results - EditMode
           path: artifacts
 
   unityTestPlayModeScripts:
@@ -155,6 +156,7 @@ jobs:
           projectPath: unity-ggjj/
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           testMode: PlayMode
+          checkName: Test Results - PlayMode Scripts
           customParameters: -debugCodeOptimization -enableCodeCoverage -coverageResultsPath ./coverage-results -coverageOptions generateAdditionalMetrics;assemblyFilters:+GG-JointJustice
 
       - name: Upload XML report to Codecov
@@ -170,7 +172,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: ${{ failure() || success() }}
         with:
-          name: Test results
+          name: Test Results - PlayMode Scripts
           path: artifacts
 
   unityTestPlayModeScenes:
@@ -207,6 +209,7 @@ jobs:
           projectPath: unity-ggjj/
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           testMode: PlayMode
+          checkName: Test Results - PlayMode Scenes
           customParameters: -debugCodeOptimization -enableCodeCoverage -coverageResultsPath ./coverage-results -coverageOptions generateAdditionalMetrics;assemblyFilters:+GG-JointJustice
 
       - name: Upload XML report to Codecov
@@ -222,7 +225,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: ${{ failure() || success() }}
         with:
-          name: Test results
+          name: Test Results - PlayMode Scenes
           path: artifacts
 
   unityBuild:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,8 +72,8 @@ jobs:
           name: ${{ steps.getManualLicenseFile.outputs.filePath }}
           path: ${{ steps.getManualLicenseFile.outputs.filePath }}
 
-  unityTest:
-    name: Run PlayMode and EditorMode tests for Unity project
+  unityTestEditMode: 
+    name: Run EditMode tests for Unity project
     needs: [checkLicense]
     if: needs.checkLicense.outputs.is_unity_serial_set == 'true'
     runs-on: ubuntu-latest
@@ -90,7 +90,10 @@ jobs:
           git add .
           git reset --hard
 
-      - name: Run PlayMode and EditMode tests
+      - name: Remove unity-ggjj/Assets/Tests/PlayModeTests/ folder
+        run: rm -rf unity-ggjj/Assets/Tests/PlayModeTests/
+
+      - name: Run tests
         uses: game-ci/unity-test-runner@v2.0-alpha-6
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
@@ -99,14 +102,119 @@ jobs:
         with:
           projectPath: unity-ggjj/
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          testMode: EditMode
           customParameters: -debugCodeOptimization -enableCodeCoverage -coverageResultsPath ./coverage-results -coverageOptions generateAdditionalMetrics;assemblyFilters:+GG-JointJustice
 
       - name: Upload XML report to Codecov
         uses: codecov/codecov-action@v2
         if: ${{ failure() || success() }}
         with:
-          name: EditMode+PlayMode
-          flags: automated
+          name: EditMode
+          flags: EditMode
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: unity-ggjj/coverage-results/**/*.xml
+
+      - name: Store test artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() || success() }}
+        with:
+          name: Test results
+          path: artifacts
+
+  unityTestPlayModeScripts:
+    name: Run PlayMode Scenes tests for Unity project
+    needs: [checkLicense]
+    if: needs.checkLicense.outputs.is_unity_serial_set == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+
+      - name: Remove unity-ggjj/Assets/Tests/EditModeTests folder
+        run: rm -rf unity-ggjj/Assets/Tests/EditModeTests
+
+      - name: Remove unity-ggjj/Assets/Tests/PlayModeTests/Scenes folder
+        run: rm -rf unity-ggjj/Assets/Tests/PlayModeTests/Scenes
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v2.0-alpha-6
+        env:
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          projectPath: unity-ggjj/
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          testMode: PlayMode
+          customParameters: -debugCodeOptimization -enableCodeCoverage -coverageResultsPath ./coverage-results -coverageOptions generateAdditionalMetrics;assemblyFilters:+GG-JointJustice
+
+      - name: Upload XML report to Codecov
+        uses: codecov/codecov-action@v2
+        if: ${{ failure() || success() }}
+        with:
+          name: PlayMode Scripts
+          flags: PlayModeScripts
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: unity-ggjj/coverage-results/**/*.xml
+
+      - name: Store test artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() || success() }}
+        with:
+          name: Test results
+          path: artifacts
+
+  unityTestPlayModeScenes:
+    name: Run PlayMode Scripts tests for Unity project
+    needs: [checkLicense]
+    if: needs.checkLicense.outputs.is_unity_serial_set == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Create LFS file list
+        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+
+      - name: Git LFS Pull
+        run: |
+          git lfs pull
+          git add .
+          git reset --hard
+
+      - name: Remove unity-ggjj/Assets/Tests/EditModeTests folder
+        run: rm -rf unity-ggjj/Assets/Tests/EditModeTests
+
+      - name: Remove unity-ggjj/Assets/Tests/PlayModeTests/Scripts folder
+        run: rm -rf unity-ggjj/Assets/Tests/PlayModeTests/Scripts
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v2.0-alpha-6
+        env:
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          projectPath: unity-ggjj/
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          testMode: PlayMode
+          customParameters: -debugCodeOptimization -enableCodeCoverage -coverageResultsPath ./coverage-results -coverageOptions generateAdditionalMetrics;assemblyFilters:+GG-JointJustice
+
+      - name: Upload XML report to Codecov
+        uses: codecov/codecov-action@v2
+        if: ${{ failure() || success() }}
+        with:
+          name: PlayMode Scenes
+          flags: PlayModeScenes
           token: ${{ secrets.CODECOV_TOKEN }}
           files: unity-ggjj/coverage-results/**/*.xml
 


### PR DESCRIPTION
## Summary
This change **does not change game code**.

Right now tests are split into...
- [EditMode tests](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/tree/develop/unity-ggjj/Assets/Tests/EditModeTests)
  - treated as **unit tests** for code that **have a dependency on `UnityEditor`** or **no dependency on `UnityEngine`**
- [PlayMode tests `/Scripts`](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/tree/develop/unity-ggjj/Assets/Tests/PlayModeTests/Scripts)
  - treated as **unit tests** for code that **have no dependency on `UnityEditor`** AND **have a dependency on `UnityEngine`**
- [PlayMode tests `/Scenes`](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/tree/develop/unity-ggjj/Assets/Tests/PlayModeTests/Scenes)
  - roughly treated as **integration tests**

However, our current coverage reports only display the sum of all coverages, not in which types of tests certain parts of code are covered.
## Before/after screenshots and/or animated gif
### Before
All tests are grouped under the "automated" flag:
![image](https://user-images.githubusercontent.com/1689033/158990863-bdc6c045-24e9-4a8c-81fa-9001553ff42c.png)

### After
All tests will continue to have the `automated` flag (to retain historic coverage data) but will additionally be grouped by
- `EditMode`
- `PlayModeScripts`
- `PlayModeScenes`
![image](https://user-images.githubusercontent.com/1689033/158991325-173c1d88-d7ae-41ab-aa97-f27076d6a36a.png)
It will also be possible to browse coverage for a file for only a specific (group of) flags on CodeCov.io and lines in the code viewer highlight which lines are covered (green) or not covered (red) based on the selected flags.

https://user-images.githubusercontent.com/1689033/158991289-98891a5f-2c00-4b4c-b28b-674e011d66da.mp4

## Testing instructions
This is [how a report will look like](https://codecov.io/gh/Studio-Lovelies/GG-JointJustice-Unity/tree/5c38ebdda411cd5658def125a498e4ef9d0908af/unity-ggjj).
Here is a link to [the file with the dropdown selector](https://app.codecov.io/gh/Studio-Lovelies/GG-JointJustice-Unity/blob/5c38ebdda411cd5658def125a498e4ef9d0908af/unity-ggjj/Assets/Scripts/TextDecoder/ActionDecoder.cs).
The CodeCov reporter will comment on this PR after the builds are finished.

To test this for yourself:
1. Make a PR onto this branch (`feature/split-coverage-reports`)
2. Wait for builds to finish
3. Check out the comment and link insides it created by the CodeCov bot

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[ ]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->
