### PR TITLE
Fix PlayMode tests on GitHub Actions using class instances

### DIFF
--- a/unity-ggjj/Assets/Scripts/AudioController/MusicFader.cs
+++ b/unity-ggjj/Assets/Scripts/AudioController/MusicFader.cs
@@ -41,6 +41,7 @@ public class MusicFader
     /// <returns>WaitUntil object that returns control to the coroutine when it's finished</returns>
     public WaitUntil FadeOut(float seconds = 1f)
     {
+        var startTime = Time.time;
         return new WaitUntil(() =>
         {
             if (seconds <= 0)
@@ -49,17 +50,17 @@ public class MusicFader
                 return true;
             }
 
-            NormalizedVolume -= Time.deltaTime / seconds;
+            NormalizedVolume = Mathf.Lerp(1f, 0f, (Time.time - startTime) / seconds);
 
-            if (NormalizedVolume <= 0)
-            {
-                NormalizedVolume = 0;
-                return true;
-            }
-            else
+            // not enough time has passed
+            if (Time.time - startTime <= seconds)
             {
                 return false;
             }
+
+            NormalizedVolume = 0;
+            return true;
+
         });
     }
 }

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scenes/CrossExamination/ViaKeyboard.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scenes/CrossExamination/ViaKeyboard.cs
@@ -2,7 +2,6 @@
 using NUnit.Framework;
 using Tests.PlayModeTests.Tools;
 using UnityEngine;
-using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
@@ -11,29 +10,38 @@ namespace Tests.PlayModeTests.Scenes.CrossExamination
 {
     public class ViaKeyboard
     {
-        private readonly InputTestTools _inputTestTools = new InputTestTools();
+        private readonly StoryProgresser _storyProgresser = new StoryProgresser();
+        
         private NarrativeScriptPlayerComponent _narrativeScriptPlayerComponent;
-        private StoryProgresser _storyProgresser;
 
-        private Keyboard Keyboard => _inputTestTools.Keyboard;
+        [SetUp]
+        public void Setup()
+        {
+            _storyProgresser.Setup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _storyProgresser.TearDown();
+        }
 
         [UnitySetUp]
-        public IEnumerator SetUp()
+        public IEnumerator UnitySetUp()
         {
             yield return SceneManager.LoadSceneAsync("Game");
             TestTools.StartGame("RossCoolX");
             _narrativeScriptPlayerComponent = Object.FindObjectOfType<NarrativeScriptPlayerComponent>();
-            _storyProgresser = new StoryProgresser();
         }
-        
+
         [UnityTest]
         public IEnumerator CanPresentEvidenceDuringExamination()
         {
             yield return _storyProgresser.ProgressStory();
             EvidenceMenu evidenceMenu = Object.FindObjectOfType<EvidenceMenu>(true);
-            yield return _inputTestTools.PressForFrame(Keyboard.zKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.zKey);
             Assert.True(evidenceMenu.isActiveAndEnabled);
-            yield return _inputTestTools.PressForFrame(Keyboard.enterKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.enterKey);
             Assert.False(evidenceMenu.isActiveAndEnabled);
             Assert.IsTrue(_narrativeScriptPlayerComponent.NarrativeScriptPlayer.HasSubStory);
         }
@@ -43,15 +51,15 @@ namespace Tests.PlayModeTests.Scenes.CrossExamination
         {
             EvidenceMenu evidenceMenu = TestTools.FindInactiveInScene<EvidenceMenu>()[0];
             yield return _storyProgresser.ProgressStory();
-            yield return _inputTestTools.WaitForBehaviourActiveAndEnabled(evidenceMenu, Keyboard.zKey);
+            yield return _storyProgresser.WaitForBehaviourActiveAndEnabled(evidenceMenu, _storyProgresser.Keyboard.zKey);
             Assert.True(evidenceMenu.isActiveAndEnabled);
-            yield return _inputTestTools.PressForFrame(Keyboard.enterKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.enterKey);
             Assert.False(evidenceMenu.isActiveAndEnabled);
             Assert.IsTrue(_narrativeScriptPlayerComponent.NarrativeScriptPlayer.HasSubStory);
 
-            yield return _inputTestTools.WaitForBehaviourActiveAndEnabled(evidenceMenu, Keyboard.zKey);
+            yield return _storyProgresser.WaitForBehaviourActiveAndEnabled(evidenceMenu, _storyProgresser.Keyboard.zKey);
             Assert.True(evidenceMenu.isActiveAndEnabled);
-            yield return _inputTestTools.PressForFrame(Keyboard.enterKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.enterKey);
             Assert.True(evidenceMenu.isActiveAndEnabled);
         }
 
@@ -61,13 +69,13 @@ namespace Tests.PlayModeTests.Scenes.CrossExamination
             var narrativeScriptPlayer = Object.FindObjectOfType<NarrativeScriptPlayerComponent>();
             
             yield return _storyProgresser.ProgressStory();
-            yield return _inputTestTools.PressForFrame(Keyboard.cKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.cKey);
             yield return TestTools.WaitForState(() => !narrativeScriptPlayer.NarrativeScriptPlayer.Waiting);
 
             EvidenceMenu evidenceMenu = TestTools.FindInactiveInScene<EvidenceMenu>()[0];
-            yield return _inputTestTools.WaitForBehaviourActiveAndEnabled(evidenceMenu, Keyboard.zKey);
+            yield return _storyProgresser.WaitForBehaviourActiveAndEnabled(evidenceMenu, _storyProgresser.Keyboard.zKey);
             Assert.True(evidenceMenu.isActiveAndEnabled);
-            yield return _inputTestTools.PressForFrame(Keyboard.enterKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.enterKey);
             Assert.True(evidenceMenu.isActiveAndEnabled);
         }
 
@@ -75,18 +83,17 @@ namespace Tests.PlayModeTests.Scenes.CrossExamination
         public IEnumerator GameOverPlaysOnNoLivesLeft()
         {
             var penaltyManager = Object.FindObjectOfType<PenaltyManager>();
-            var storyProgresser = new StoryProgresser();
             
             for (int i = penaltyManager.PenaltiesLeft; i > 0; i--)
             {
                 yield return TestTools.WaitForState(() => _narrativeScriptPlayerComponent.NarrativeScriptPlayer.CanPressWitness);
 
                 Assert.AreEqual(i, penaltyManager.PenaltiesLeft);
-                yield return _inputTestTools.PressForFrame(_inputTestTools.Keyboard.zKey);
-                yield return _inputTestTools.PressForFrame(_inputTestTools.Keyboard.enterKey);
+                yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.zKey);
+                yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.enterKey);
                 while (_narrativeScriptPlayerComponent.NarrativeScriptPlayer.HasSubStory && penaltyManager.PenaltiesLeft > 0)
                 {
-                    yield return storyProgresser.ProgressStory();
+                    yield return _storyProgresser.ProgressStory();
                 }
 
                 Assert.AreEqual(i - 1, penaltyManager.PenaltiesLeft);

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scenes/MainMenu/ViaKeyboard.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scenes/MainMenu/ViaKeyboard.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using NUnit.Framework;
 using Tests.PlayModeTests.Tools;
-using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
@@ -12,14 +11,27 @@ namespace Tests.PlayModeTests.Scenes.MainMenu
     public class ViaKeyboard
     {
         private readonly InputTestTools _inputTestTools = new InputTestTools();
-        private Keyboard Keyboard => _inputTestTools.Keyboard;
+        private Keyboard Keyboard;
+
+        [SetUp]
+        public void Setup()
+        {
+            _inputTestTools.Setup();
+            Keyboard = _inputTestTools.Keyboard;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _inputTestTools.TearDown();
+        }
 
         [UnitySetUp]
-        public IEnumerator SetUp()
+        public IEnumerator UnitySetUp()
         {
             yield return SceneManager.LoadSceneAsync("MainMenu");
         }
-        
+
         [UnityTest]
         public IEnumerator CanEnterAndCloseTwoSubMenusIndividually()
         {

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scenes/MainMenu/ViaMouse.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scenes/MainMenu/ViaMouse.cs
@@ -12,14 +12,27 @@ namespace Tests.PlayModeTests.Scenes.MainMenu
     public class ViaMouse
     {
         private readonly InputTestTools _inputTestTools = new InputTestTools();
-        private Mouse Mouse => _inputTestTools.Mouse;
+        private Mouse Mouse;
+
+        [SetUp]
+        public void Setup()
+        {
+            _inputTestTools.Setup();
+            Mouse = _inputTestTools.Mouse;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _inputTestTools.TearDown();
+        }
 
         [UnitySetUp]
         public IEnumerator SetUp()
         {
             yield return SceneManager.LoadSceneAsync("MainMenu");
         }
-        
+
         [UnityTest]
         public IEnumerator CanEnterAndCloseTwoSubMenusIndividually()
         {

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scenes/Visibility/ViaKeyboard.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scenes/Visibility/ViaKeyboard.cs
@@ -1,56 +1,69 @@
 ﻿using System.Collections;
 using Tests.PlayModeTests.Tools;
+using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.Assertions;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
+using Assert = UnityEngine.Assertions.Assert;
 
 namespace Tests.PlayModeTests.Scenes.VisibilityTest
 {
     public class ViaKeyboard
     {
+        private readonly StoryProgresser _storyProgresser = new StoryProgresser();
+
+        [SetUp]
+        public void Setup()
+        {
+            _storyProgresser.Setup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _storyProgresser.TearDown();
+        }
+
         [UnitySetUp]
-        public IEnumerator SetUp()
+        public IEnumerator UnitySetUp()
         {
             yield return SceneManager.LoadSceneAsync("Game");
         }
-        
+
         [UnityTest]
         public IEnumerator RendererChangesVisibility()
         {
             TestTools.StartGame("VisibilityTest");
             
-            var storyProgresser = new StoryProgresser();
-            
             var arinSprite = TestTools.FindInactiveInSceneByName<Renderer>("Defense_Actor");
             var rossSprite = TestTools.FindInactiveInSceneByName<Renderer>("Witness_Actor");
 
-            yield return storyProgresser.ProgressStory();
-            yield return storyProgresser.ProgressStory();
+            yield return _storyProgresser.ProgressStory();
+            yield return _storyProgresser.ProgressStory();
 
             Assert.IsTrue(arinSprite.enabled);
             Assert.IsTrue(rossSprite.enabled);
 
-            yield return storyProgresser.ProgressStory();
-            yield return storyProgresser.ProgressStory();
+            yield return _storyProgresser.ProgressStory();
+            yield return _storyProgresser.ProgressStory();
 
             Assert.IsTrue(arinSprite.enabled);
             Assert.IsFalse(rossSprite.enabled);
 
-            yield return storyProgresser.ProgressStory();
-            yield return storyProgresser.ProgressStory();
+            yield return _storyProgresser.ProgressStory();
+            yield return _storyProgresser.ProgressStory();
 
             Assert.IsFalse(arinSprite.enabled);
             Assert.IsFalse(rossSprite.enabled);
 
-            yield return storyProgresser.ProgressStory();
-            yield return storyProgresser.ProgressStory();
+            yield return _storyProgresser.ProgressStory();
+            yield return _storyProgresser.ProgressStory();
 
             Assert.IsFalse(arinSprite.enabled);
             Assert.IsTrue(rossSprite.enabled);
 
-            yield return storyProgresser.ProgressStory();
-            yield return storyProgresser.ProgressStory();
+            yield return _storyProgresser.ProgressStory();
+            yield return _storyProgresser.ProgressStory();
 
             Assert.IsTrue(arinSprite.enabled);
             Assert.IsTrue(rossSprite.enabled);

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/ActorControllerTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/ActorControllerTests.cs
@@ -14,24 +14,29 @@ namespace Tests.PlayModeTests.Scripts.ActorController
     {
         const string TALKING_PARAMETER_NAME = "Talking";
         
-        private readonly InputTestTools _inputTestTools = new InputTestTools();
-        private StoryProgresser _storyProgresser;
+        private StoryProgresser _storyProgresser = new StoryProgresser();
         private global::ActorController _actorController;
         private Animator _witnessAnimator;
 
         [UnitySetUp]
-        public IEnumerator SetUp()
+        public IEnumerator UnitySetUp()
         {
+            _storyProgresser.Setup();
             SceneManager.LoadScene("Game");
             yield return null;
             TestTools.StartGame("ActorControllerTestScript");
 
-            _storyProgresser = new StoryProgresser();
             _actorController = Object.FindObjectOfType<global::ActorController>();
             
             yield return _storyProgresser.ProgressStory();
             _witnessAnimator = GameObject.Find("Witness_Actor").GetComponent<Actor>().GetComponent<Animator>();
             AssertIsNotTalking(_witnessAnimator);
+        }
+
+        [UnityTearDown]
+        public void UnityTearDown()
+        {
+            _storyProgresser.TearDown();
         }
 
         [UnityTest]
@@ -48,7 +53,7 @@ namespace Tests.PlayModeTests.Scripts.ActorController
         [UnityTest]
         public IEnumerator ActorsAreSetToTalkingOnDialogueStart()
         {
-            yield return _inputTestTools.PressForFrame(_inputTestTools.Keyboard.xKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.xKey);
             AssertIsTalking(_witnessAnimator);
         }
 
@@ -65,7 +70,7 @@ namespace Tests.PlayModeTests.Scripts.ActorController
         {
             var prosecutionAnimator =  GameObject.Find("Prosecution_Actor").GetComponent<Actor>().GetComponent<Animator>();
             _actorController.SetActiveSpeaker("TutorialBoy", SpeakingType.Speaking);
-            yield return _inputTestTools.PressForFrame(_inputTestTools.Keyboard.xKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.xKey);
             AssertIsTalking(prosecutionAnimator);
             AssertIsNotTalking(_witnessAnimator);
         }
@@ -83,7 +88,7 @@ namespace Tests.PlayModeTests.Scripts.ActorController
         public IEnumerator SpeakerCanBeSetToThinking()
         {
             _actorController.SetActiveSpeaker("Arin", SpeakingType.Thinking);
-            yield return _inputTestTools.PressForFrame(_inputTestTools.Keyboard.xKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.xKey);
             AssertIsNotTalking(_witnessAnimator);
             AssertNameBoxCorrect();
         }
@@ -94,7 +99,7 @@ namespace Tests.PlayModeTests.Scripts.ActorController
             var nameBox = Object.FindObjectOfType<NameBox>().gameObject;
 
             _actorController.SetActiveSpeakerToNarrator();
-            yield return _inputTestTools.PressForFrame(_inputTestTools.Keyboard.xKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.xKey);
             AssertIsNotTalking(_witnessAnimator);
             Assert.IsFalse(nameBox.activeInHierarchy);
         }
@@ -135,7 +140,7 @@ namespace Tests.PlayModeTests.Scripts.ActorController
         public IEnumerator ActorNotInTheSceneCanSpeak()
         {
             _actorController.SetActiveSpeaker("Dan", SpeakingType.Speaking);
-            yield return _inputTestTools.PressForFrame(_inputTestTools.Keyboard.xKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.xKey);
             AssertIsNotTalking(_witnessAnimator);
             AssertNameBoxCorrect();
         }

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/AudioController/AudioControllerTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/AudioController/AudioControllerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using NUnit.Framework;
 using Tests.PlayModeTests.Tools;
@@ -88,10 +89,14 @@ namespace Tests.PlayModeTests.Scripts.AudioController
         [UnityTest]
         public IEnumerator SongsCanBeFadedOut()
         {
-            const float TRANSITION_DURATION = 2;
+            const float TRANSITION_DURATION_IN_SECONDS = 2;
             yield return SongsCanBePlayedWithoutFadeIn();
-            _audioController.FadeOutSong(TRANSITION_DURATION);
-            yield return new WaitForSeconds(TRANSITION_DURATION);
+            var expectedEndTimeOfFadeOut = Time.time + TRANSITION_DURATION_IN_SECONDS;
+            _audioController.FadeOutSong(TRANSITION_DURATION_IN_SECONDS);
+            yield return TestTools.WaitForState(() => _audioSource.volume == 0);
+
+            // This should take at least TRANSITION_DURATION_IN_SECONDS
+            Assert.GreaterOrEqual(Time.time, expectedEndTimeOfFadeOut);
             Assert.AreEqual(0, _audioSource.volume);
         }
 

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/AudioController/AudioControllerTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/AudioController/AudioControllerTests.cs
@@ -32,7 +32,7 @@ namespace Tests.PlayModeTests.Scripts.AudioController
         }
         
         [UnityTest]
-        public IEnumerator AudioController_PlaySong_FadesBetweenSongs()
+        public IEnumerator FadesBetweenSongs()
         {
             const float TRANSITION_DURATION = 2f;
             var settingsMusicVolume = TestTools.GetField<float>(_audioController, "_settingsMusicVolume");
@@ -40,39 +40,33 @@ namespace Tests.PlayModeTests.Scripts.AudioController
             // setup and verify steady state of music playing for a while
             var firstSong = LoadSong("aBoyAndHisTrial");
             _audioController.PlaySong(firstSong, TRANSITION_DURATION);
-            yield return new WaitForSeconds(TRANSITION_DURATION);
 
-            Assert.AreEqual(_audioSource.volume, settingsMusicVolume);
+            yield return TestTools.WaitForState(() => _audioSource.volume == settingsMusicVolume, TRANSITION_DURATION*2);
             Assert.AreEqual(firstSong.name, _audioSource.clip.name);
 
             // transition into new song
             var secondSong = LoadSong("aKissFromARose");
             _audioController.PlaySong(secondSong, TRANSITION_DURATION);
-            yield return new WaitForSeconds(TRANSITION_DURATION/10f);
+            yield return TestTools.WaitForState(() => _audioSource.volume != settingsMusicVolume, TRANSITION_DURATION);
 
             // expect old song to still be playing, but no longer at full volume, as we're transitioning
             Assert.AreNotEqual(_audioSource.volume, settingsMusicVolume);
             Assert.AreEqual(firstSong.name, _audioSource.clip.name);
 
-            yield return new WaitForSeconds(TRANSITION_DURATION);
-
             // expect new song to be playing at full volume, as we're done transitioning
-            Assert.AreEqual(_audioSource.volume, settingsMusicVolume);
+            yield return TestTools.WaitForState(() => _audioSource.volume == settingsMusicVolume, TRANSITION_DURATION*2);
             Assert.AreEqual(secondSong.name, _audioSource.clip.name);
 
             // transition into new song
             var thirdSong = LoadSong("investigationJoonyer");
             _audioController.PlaySong(thirdSong, TRANSITION_DURATION);
-            yield return new WaitForSeconds(TRANSITION_DURATION/10f);
 
             // expect old song to still be playing, but no longer at full volume, as we're transitioning
-            Assert.AreNotEqual(_audioSource.volume, settingsMusicVolume);
+            yield return TestTools.WaitForState(() => _audioSource.volume != settingsMusicVolume, TRANSITION_DURATION);
             Assert.AreEqual(secondSong.name, _audioSource.clip.name);
 
-            yield return new WaitForSeconds(TRANSITION_DURATION);
-
             // expect new song to be playing at full volume, as we're done transitioning
-            Assert.AreEqual(_audioSource.volume, settingsMusicVolume);
+            yield return TestTools.WaitForState(() => _audioSource.volume == settingsMusicVolume, TRANSITION_DURATION*2);
             Assert.AreEqual(thirdSong.name, _audioSource.clip.name);
         }
 

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/EvidenceMenu/EvidenceMenuKeyboardTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/EvidenceMenu/EvidenceMenuKeyboardTests.cs
@@ -32,7 +32,7 @@ namespace Tests.PlayModeTests.Scripts.EvidenceMenu
         public IEnumerator EvidenceMenuCannotBeClosedWhenPresentingEvidence()
         {
             EvidenceController.RequirePresentEvidence();
-            yield return InputTestTools.WaitForBehaviourActiveAndEnabled(EvidenceMenu, InputTestTools.Keyboard.xKey);
+            yield return _storyProgresser.WaitForBehaviourActiveAndEnabled(EvidenceMenu, _storyProgresser.Keyboard.xKey);
             Assert.True(EvidenceMenu.isActiveAndEnabled);
             yield return PressZ();
             Assert.True(EvidenceMenu.isActiveAndEnabled);
@@ -42,10 +42,10 @@ namespace Tests.PlayModeTests.Scripts.EvidenceMenu
         public IEnumerator IncorrectEvidenceCanBePresented()
         {
             AddEvidence();
-            yield return StoryProgresser.ProgressStory();
-            yield return StoryProgresser.ProgressStory();
-            yield return InputTestTools.PressForFrame(InputTestTools.Keyboard.rightArrowKey);
-            yield return InputTestTools.PressForFrame(InputTestTools.Keyboard.enterKey);
+            yield return _storyProgresser.ProgressStory();
+            yield return _storyProgresser.ProgressStory();
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.rightArrowKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.enterKey);
             var narrativeScriptPlayer = Object.FindObjectOfType<NarrativeScriptPlayerComponent>();
             Assert.IsTrue(narrativeScriptPlayer.NarrativeScriptPlayer.HasSubStory);
         }
@@ -54,7 +54,7 @@ namespace Tests.PlayModeTests.Scripts.EvidenceMenu
         public IEnumerator CorrectEvidenceCanBePresented()
         {
             yield return SelectEvidence("Evidence/BentCoins");
-            yield return StoryProgresser.ProgressStory();
+            yield return _storyProgresser.ProgressStory();
             var speechPanel = GameObject.Find("Dialogue").GetComponent<TextMeshProUGUI>();
             Assert.IsTrue(speechPanel.text == "Correct");
         }
@@ -62,8 +62,8 @@ namespace Tests.PlayModeTests.Scripts.EvidenceMenu
         private IEnumerator SelectEvidence(string evidencePath)
         {
             EvidenceController.AddEvidence(Resources.Load<Evidence>(evidencePath));
-            yield return TestTools.DoUntilStateIsReached(() => StoryProgresser.ProgressStory(), () => EvidenceMenu.isActiveAndEnabled);
-            yield return InputTestTools.PressForFrame(InputTestTools.Keyboard.enterKey);
+            yield return TestTools.DoUntilStateIsReached(() => _storyProgresser.ProgressStory(), () => EvidenceMenu.isActiveAndEnabled);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.enterKey);
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace Tests.PlayModeTests.Scripts.EvidenceMenu
             
             // Spam navigation button
             yield return PressLeft();
-            yield return InputTestTools.PressForFrame(InputTestTools.Keyboard.enterKey, 50);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.enterKey, 50);
 
             yield return PressRight();
             yield return CheckItems(Object.FindObjectsOfType<EvidenceMenuItem>().Length);
@@ -110,7 +110,7 @@ namespace Tests.PlayModeTests.Scripts.EvidenceMenu
             
             // Spam navigation button
             yield return PressRight();
-            yield return InputTestTools.PressForFrame(InputTestTools.Keyboard.enterKey, 101);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.enterKey, 101);
             yield return PressLeft();
 
             // After all this "Stolen Dinos" should be selected
@@ -170,17 +170,17 @@ namespace Tests.PlayModeTests.Scripts.EvidenceMenu
 
         private IEnumerator PressC()
         {
-            yield return InputTestTools.PressForFrame(InputTestTools.Keyboard.cKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.cKey);
         }
 
         private IEnumerator PressLeft()
         {
-            yield return InputTestTools.PressForFrame(InputTestTools.Keyboard.leftArrowKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.leftArrowKey);
         }
 
         private IEnumerator PressRight()
         {
-            yield return InputTestTools.PressForFrame(InputTestTools.Keyboard.rightArrowKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.rightArrowKey);
         }
     }
 }

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/EvidenceMenu/EvidenceMenuMouseTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/EvidenceMenu/EvidenceMenuMouseTests.cs
@@ -11,8 +11,6 @@ namespace Tests.PlayModeTests.Scripts.EvidenceMenu
 {
     public class EvidenceMenuMouseTests : EvidenceMenuTest
     {
-        private readonly InputTestTools _inputTestTools = new InputTestTools();
-
         /// <summary>
         /// Places mouse over each menu item and asserts it is highlighted.
         /// </summary>
@@ -90,7 +88,7 @@ namespace Tests.PlayModeTests.Scripts.EvidenceMenu
                 yield return HoverOverButton(menuItem.transform);
                 var clicked = false;
                 menuItem.GetComponent<Button>().onClick.AddListener(() => clicked = true);
-                yield return InputTestTools.PressForFrame(InputTestTools.Mouse.leftButton);
+                yield return _storyProgresser.PressForFrame(_storyProgresser.Mouse.leftButton);
                 Assert.IsTrue(clicked);
             }
         }
@@ -107,12 +105,12 @@ namespace Tests.PlayModeTests.Scripts.EvidenceMenu
 
         private IEnumerator HoverOverButton(Transform transform)
         {
-            yield return _inputTestTools.SetMouseWorldSpacePosition(transform.TransformPoint(transform.GetComponent<RectTransform>().rect.center));
+            yield return _storyProgresser.SetMouseWorldSpacePosition(transform.TransformPoint(transform.GetComponent<RectTransform>().rect.center));
         }
 
         private IEnumerator LeftClick()
         {
-            yield return _inputTestTools.PressForFrame(_inputTestTools.Mouse.leftButton);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Mouse.leftButton);
         }
     }
 }

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/EvidenceMenu/EvidenceMenuTest.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/EvidenceMenu/EvidenceMenuTest.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Linq;
+using NUnit.Framework;
 using Tests.PlayModeTests.Tools;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -9,13 +10,24 @@ namespace Tests.PlayModeTests.Scripts.EvidenceMenu
 {
     public class EvidenceMenuTest
     {
-        protected InputTestTools InputTestTools { get; } = new InputTestTools();
         protected EvidenceController EvidenceController { get; private set; }
         protected NarrativeScriptPlayerComponent NarrativeScriptPlayerComponent { get; private set; }
         protected global::EvidenceMenu EvidenceMenu { get; private set; }
         protected Transform CanvasTransform { get; private set; }
         protected Menu Menu { get; private set; }
-        protected StoryProgresser StoryProgresser { get; private set; }
+        protected StoryProgresser _storyProgresser = new StoryProgresser();
+
+        [SetUp]
+        public void Setup()
+        {
+            _storyProgresser.Setup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _storyProgresser.TearDown();
+        }
 
         [UnitySetUp]
         public IEnumerator SetUp()
@@ -23,7 +35,6 @@ namespace Tests.PlayModeTests.Scripts.EvidenceMenu
             yield return SceneManager.LoadSceneAsync("Game");
             TestTools.StartGame("AddRecordTest");
 
-            StoryProgresser = new StoryProgresser();
             EvidenceController = Object.FindObjectOfType<EvidenceController>();
             NarrativeScriptPlayerComponent = Object.FindObjectOfType<NarrativeScriptPlayerComponent>();
             EvidenceMenu = TestTools.FindInactiveInScene<global::EvidenceMenu>()[0];
@@ -58,7 +69,7 @@ namespace Tests.PlayModeTests.Scripts.EvidenceMenu
         
         protected IEnumerator PressZ()
         {
-            yield return InputTestTools.PressForFrame(InputTestTools.Keyboard.zKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.zKey);
         }
     }
 }

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/FullScreenAnimationTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/FullScreenAnimationTests.cs
@@ -10,7 +10,20 @@ namespace Tests.PlayModeTests.Scripts
     public class FullScreenAnimation
     {
         private readonly InputTestTools _inputTestTools = new InputTestTools();
-        
+
+        [SetUp]
+        public void Setup()
+        {
+            _inputTestTools.Setup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _inputTestTools.TearDown();
+        }
+
+
         [UnityTest]
         public IEnumerator FullScreenAnimationsCannotBeSkipped()
         {

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/LoadScriptTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/LoadScriptTests.cs
@@ -11,16 +11,27 @@ namespace Tests.PlayModeTests.Scripts
 {
     public class LoadScriptTests
     {
-        private StoryProgresser _storyProgresser;
+        private StoryProgresser _storyProgresser = new StoryProgresser();
 
+        [SetUp]
+        public void Setup()
+        {
+            _storyProgresser.Setup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _storyProgresser.TearDown();
+        }
+       
         [UnitySetUp]
-        public IEnumerator SetUp()
+        public IEnumerator UnitySetUp()
         {
             yield return SceneManager.LoadSceneAsync("Game");
             TestTools.StartGame("LoadScriptTest");
-            _storyProgresser = new StoryProgresser();
         }
-        
+
         [UnityTest]
         public IEnumerator NarrativeScriptsCanBeLoaded()
         {

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/PauseMenu/PauseMenuTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/PauseMenu/PauseMenuTests.cs
@@ -24,15 +24,29 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
         
         protected Menu PauseMenu { get; private set; }
         protected Button[] Buttons { get; private set; }
-        protected InputTestTools InputTools { get; }= new InputTestTools();
-        protected Keyboard Keyboard => InputTools.Keyboard;
+        protected Keyboard Keyboard;
         protected float CanvasScale { get; private set; }
+
+        protected readonly InputTestTools _inputTestTools = new InputTestTools();
+
+        [SetUp]
+        public void Setup()
+        {
+            _inputTestTools.Setup();
+            Keyboard = _inputTestTools.Keyboard;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _inputTestTools.TearDown();
+        }
 
         /// <summary>
         /// Loads the correct scene and gets the required objects before every test.
         /// </summary>
         [UnitySetUp]
-        protected IEnumerator SetUp()
+        protected IEnumerator UnitySetUp()
         {
             yield return SceneManager.LoadSceneAsync("Game");
             PauseMenu = TestTools.FindInactiveInSceneByName<Menu>("PauseMenu");
@@ -61,7 +75,7 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
         /// </summary>
         protected IEnumerator ToggleMenu()
         {
-            yield return InputTools.PressForFrame(Keyboard.escapeKey);
+            yield return _inputTestTools.PressForFrame(Keyboard.escapeKey);
         }
 
         /// <summary>
@@ -91,7 +105,7 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
         /// <param name="selectionMethod">A coroutine that navigates to and clicks the resume button.</param>
         protected IEnumerator TestResumeButton(Func<IEnumerator> selectionMethod)
         {
-            yield return InputTools.PressForFrame(Keyboard.escapeKey);
+            yield return _inputTestTools.PressForFrame(Keyboard.escapeKey);
             Assert.IsTrue(PauseMenu.isActiveAndEnabled);
             yield return selectionMethod();
             Assert.IsFalse(PauseMenu.isActiveAndEnabled);
@@ -105,13 +119,13 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
         /// <param name="selectionMethod">A coroutine that navigates to and clicks the settings button.</param>
         protected IEnumerator TestSettingsButton(Func<IEnumerator> selectionMethod)
         {
-            yield return InputTools.PressForFrame(Keyboard.escapeKey);
+            yield return _inputTestTools.PressForFrame(Keyboard.escapeKey);
             Assert.IsTrue(PauseMenu.isActiveAndEnabled);
             Assert.IsNull(GameObject.Find("SettingsMenu"));
             yield return selectionMethod();
             GameObject settingsMenu = GameObject.Find("SettingsMenu");
             Assert.IsTrue(settingsMenu.activeInHierarchy);
-            yield return InputTools.PressForFrame(Keyboard.escapeKey);
+            yield return _inputTestTools.PressForFrame(Keyboard.escapeKey);
             Assert.IsFalse(settingsMenu.activeInHierarchy);
         }
 
@@ -123,7 +137,7 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
         /// <param name="selectionMethod">A coroutine that navigates to and clicks the main menu button.</param>
         protected IEnumerator TestMainMenuButton(Func<IEnumerator> selectionMethod)
         {
-            yield return InputTools.PressForFrame(Keyboard.escapeKey);
+            yield return _inputTestTools.PressForFrame(Keyboard.escapeKey);
             Assert.IsTrue(PauseMenu.isActiveAndEnabled);
             yield return selectionMethod();
             yield return TestTools.WaitForState(() => SceneManager.GetActiveScene().name == "MainMenu");

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/PauseMenu/ViaKeyboard.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/PauseMenu/ViaKeyboard.cs
@@ -13,9 +13,9 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
         public IEnumerator PauseMenuCanBeOpenedAndClosed()
         {
             AssertMenuInactive();
-            yield return InputTools.PressForFrame(Keyboard.escapeKey);
+            yield return _inputTestTools.PressForFrame(Keyboard.escapeKey);
             AssertMenuActive();
-            yield return InputTools.PressForFrame(Keyboard.escapeKey);
+            yield return _inputTestTools.PressForFrame(Keyboard.escapeKey);
             AssertMenuInactive();
         }
 
@@ -28,7 +28,7 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
         [UnityTest]
         public IEnumerator PauseMenuCanBeNavigated()
         {
-            yield return InputTools.PressForFrame(Keyboard.escapeKey);
+            yield return _inputTestTools.PressForFrame(Keyboard.escapeKey);
             Button resumeButton = GetButton(RESUME_BUTTON_NAME);
             Button settingsButton = GetButton(SETTINGS_BUTTON_NAME);
             Button mainMenuButton = GetButton(MAIN_MENU_BUTTON_NAME);
@@ -37,28 +37,28 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
             for (int i = 0; i < 2; i++)
             { 
                 AssertButtonSelected(resumeButton);
-                yield return InputTools.PressForFrame(Keyboard.downArrowKey);
+                yield return _inputTestTools.PressForFrame(Keyboard.downArrowKey);
                 AssertButtonSelected(settingsButton);
-                yield return InputTools.PressForFrame(Keyboard.downArrowKey);
+                yield return _inputTestTools.PressForFrame(Keyboard.downArrowKey);
                 AssertButtonSelected(mainMenuButton);
-                yield return InputTools.PressForFrame(Keyboard.downArrowKey);
+                yield return _inputTestTools.PressForFrame(Keyboard.downArrowKey);
             }
             
             // Menu can be navigated up and wrap from top to bottom
             for (int i = 0; i < 2; i++)
             {
                 AssertButtonSelected(resumeButton);
-                yield return InputTools.PressForFrame(Keyboard.upArrowKey);
+                yield return _inputTestTools.PressForFrame(Keyboard.upArrowKey);
                 AssertButtonSelected(mainMenuButton);
-                yield return InputTools.PressForFrame(Keyboard.upArrowKey);
+                yield return _inputTestTools.PressForFrame(Keyboard.upArrowKey);
                 AssertButtonSelected(settingsButton);
-                yield return InputTools.PressForFrame(Keyboard.upArrowKey);
+                yield return _inputTestTools.PressForFrame(Keyboard.upArrowKey);
             }
 
             // Navigating left and right should not select different buttons
-            yield return InputTools.PressForFrame(Keyboard.leftArrowKey);
+            yield return _inputTestTools.PressForFrame(Keyboard.leftArrowKey);
             AssertButtonSelected(resumeButton);
-            yield return InputTools.PressForFrame(Keyboard.rightArrowKey);
+            yield return _inputTestTools.PressForFrame(Keyboard.rightArrowKey);
             AssertButtonSelected(resumeButton);
         }
 
@@ -68,7 +68,7 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
         [UnityTest]
         public IEnumerator ResumeButtonResumesGame()
         {
-            yield return TestResumeButton(() => InputTools.PressForFrame(Keyboard.enterKey));
+            yield return TestResumeButton(() => _inputTestTools.PressForFrame(Keyboard.enterKey));
         }
         
         /// <summary>
@@ -94,8 +94,8 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
         /// </summary>
         private IEnumerator NavigateToAndClickSettingsButton()
         {
-            yield return InputTools.PressForFrame(Keyboard.downArrowKey);
-            yield return InputTools.PressForFrame(Keyboard.enterKey);
+            yield return _inputTestTools.PressForFrame(Keyboard.downArrowKey);
+            yield return _inputTestTools.PressForFrame(Keyboard.enterKey);
         }
 
         /// <summary>
@@ -104,8 +104,8 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
         /// <returns></returns>
         private IEnumerator NavigateToAndClickMainMenuButton()
         {
-            yield return InputTools.PressForFrame(Keyboard.upArrowKey);
-            yield return InputTools.PressForFrame(Keyboard.enterKey);
+            yield return _inputTestTools.PressForFrame(Keyboard.upArrowKey);
+            yield return _inputTestTools.PressForFrame(Keyboard.enterKey);
         }
     }
 }

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/PauseMenu/ViaMouse.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/PauseMenu/ViaMouse.cs
@@ -16,7 +16,7 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
             yield return ToggleMenu();
             foreach (var button in Buttons)
             {
-                yield return InputTools.SetMouseWorldSpacePosition(GetButtonCenter(button));
+                yield return _inputTestTools.SetMouseWorldSpacePosition(GetButtonCenter(button));
                 AssertButtonSelected(button);
             }
         }
@@ -27,7 +27,7 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
         [UnityTest]
         public IEnumerator ResumeButtonResumesGame()
         {
-            yield return TestResumeButton(() => InputTools.ClickAtWorldSpacePosition(GetButtonCenter(GetButton(RESUME_BUTTON_NAME))));
+            yield return TestResumeButton(() => _inputTestTools.ClickAtWorldSpacePosition(GetButtonCenter(GetButton(RESUME_BUTTON_NAME))));
         }
         
         /// <summary>
@@ -36,7 +36,7 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
         [UnityTest]
         public IEnumerator SettingsMenuCanBeOpenedAndClosed()
         {
-            yield return TestSettingsButton(() => InputTools.ClickAtWorldSpacePosition(GetButtonCenter(GetButton(SETTINGS_BUTTON_NAME))));
+            yield return TestSettingsButton(() => _inputTestTools.ClickAtWorldSpacePosition(GetButtonCenter(GetButton(SETTINGS_BUTTON_NAME))));
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
         [UnityTest]
         public IEnumerator MainMenuButtonReturnsToMainMenu()
         {
-            yield return TestMainMenuButton(() => InputTools.ClickAtWorldSpacePosition(GetButtonCenter(GetButton(MAIN_MENU_BUTTON_NAME))));
+            yield return TestMainMenuButton(() => _inputTestTools.ClickAtWorldSpacePosition(GetButtonCenter(GetButton(MAIN_MENU_BUTTON_NAME))));
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
             yield return ToggleMenu();
             Button button = GetButton(RESUME_BUTTON_NAME);
             AssertButtonSelected(button);
-            yield return InputTools.ClickAtWorldSpacePosition(new Vector2(10, 10));
+            yield return _inputTestTools.ClickAtWorldSpacePosition(new Vector2(10, 10));
             AssertButtonSelected(button);
         }
 

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/PenaltyManagerTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/PenaltyManagerTests.cs
@@ -12,12 +12,22 @@ namespace Tests.PlayModeTests.Scripts
     public class PenaltyManagerTests
     {
         private PenaltyManager _penaltyManager;
-        private readonly InputTestTools _inputTestTools = new InputTestTools();
+        private StoryProgresser _storyProgresser = new StoryProgresser();
 
-        public Keyboard Keyboard => _inputTestTools.Keyboard;
+        [SetUp]
+        public void Setup()
+        {
+            _storyProgresser.Setup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _storyProgresser.TearDown();
+        }
     
         [UnitySetUp]
-        public IEnumerator SetUp()
+        public IEnumerator UnitySetUp()
         {
             yield return SceneManager.LoadSceneAsync("Game");
             TestTools.StartGame("PenaltyTest");
@@ -28,16 +38,16 @@ namespace Tests.PlayModeTests.Scripts
         public IEnumerator PenaltiesAreEnabledOnCrossExaminationStart()
         {
             Assert.IsTrue(!_penaltyManager.isActiveAndEnabled || _penaltyManager.PenaltiesLeft == 0);
-            yield return _inputTestTools.PressForFrame(Keyboard.xKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.xKey);
             Assert.IsTrue(_penaltyManager.isActiveAndEnabled);
         }
     
         [UnityTest]
         public IEnumerator PenaltiesAreDisabledOnCrossExaminationEnd()
         {
-            yield return _inputTestTools.PressForFrame(Keyboard.xKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.xKey);
             Assert.IsTrue(_penaltyManager.isActiveAndEnabled);
-            yield return _inputTestTools.PressForFrame(Keyboard.xKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.xKey);
             Assert.IsFalse(_penaltyManager.isActiveAndEnabled);
         }
     
@@ -45,20 +55,18 @@ namespace Tests.PlayModeTests.Scripts
         public IEnumerator NumberOfPenaltiesCanBeReset()
         {
             var narrativeScriptPlayer = Object.FindObjectOfType<NarrativeScriptPlayerComponent>();
-            var storyProgresser = new StoryProgresser();
-
             for (int i = 0; i < 3; i++)
             {
-                yield return storyProgresser.ProgressStory();
+                yield return _storyProgresser.ProgressStory();
             }
             
-            yield return _inputTestTools.PressForFrame(Keyboard.zKey);
-            yield return _inputTestTools.PressForFrame(Keyboard.enterKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.zKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.enterKey);
 
-            yield return TestTools.DoUntilStateIsReached(() => storyProgresser.ProgressStory(), () => !narrativeScriptPlayer.NarrativeScriptPlayer.HasSubStory);
+            yield return TestTools.DoUntilStateIsReached(() => _storyProgresser.ProgressStory(), () => !narrativeScriptPlayer.NarrativeScriptPlayer.HasSubStory);
             
             Assert.AreEqual(4, _penaltyManager.PenaltiesLeft);
-            yield return _inputTestTools.PressForFrame(Keyboard.xKey);
+            yield return _storyProgresser.PressForFrame(_storyProgresser.Keyboard.xKey);
             Assert.AreEqual(5, _penaltyManager.PenaltiesLeft);
         }
     }

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Tools/InputTestTools.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Tools/InputTestTools.cs
@@ -13,8 +13,24 @@ namespace Tests.PlayModeTests.Tools
     /// </summary>
     public class InputTestTools : InputTestFixture
     {
-        public Keyboard Keyboard { get; } = InputSystem.GetDevice<Keyboard>();
-        public Mouse Mouse { get; } = InputSystem.GetDevice<Mouse>();
+        public override void Setup()
+        {
+            base.Setup();
+
+            Keyboard = InputSystem.AddDevice<Keyboard>("keyboardMock");
+            Mouse = InputSystem.AddDevice<Mouse>("mouseMock");
+        }
+
+        public override void TearDown()
+        {
+            InputSystem.RemoveDevice(Mouse);
+            InputSystem.RemoveDevice(Keyboard);
+
+            base.TearDown();
+        }
+
+        public Keyboard Keyboard;
+        public Mouse Mouse;
 
         private EditorWindow _gameViewWindow;
 

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Tools/StoryProgresser.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Tools/StoryProgresser.cs
@@ -3,24 +3,17 @@ using UnityEngine;
 
 namespace Tests.PlayModeTests.Tools
 {
-    public class StoryProgresser
+    public class StoryProgresser : InputTestTools
     {
-        private readonly InputTestTools _inputTestTools = new InputTestTools();
-        private readonly AppearingDialogueController _appearingDialogueController;
-        
-        public StoryProgresser()
-        {
-            _appearingDialogueController = Object.FindObjectOfType<AppearingDialogueController>();
-        }
-        
         /// <summary>
         /// Holds the X Key until an AppearingDialogueController is not printing text
         /// </summary>
         public IEnumerator ProgressStory()
         {
-            _inputTestTools.Press(_inputTestTools.Keyboard.xKey);
-            yield return TestTools.WaitForState(() => !_appearingDialogueController.IsPrintingText);
-            _inputTestTools.Release(_inputTestTools.Keyboard.xKey);
+            Press(Keyboard.xKey);
+            var appearingDialogueController = Object.FindObjectOfType<AppearingDialogueController>();
+            yield return TestTools.WaitForState(() => !appearingDialogueController.IsPrintingText);
+            Release(Keyboard.xKey);
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes the `PlayMode` tests on GitHub Actions (and when running in `-batchmode`).

**Resolving this issue is possible in two different approaches, which produce the same result with differing code.  
Check out the other implementation (#220) and leave feedback on the approach you would prefer and why.**

## Before/after screenshots and/or animated gif
Before:
![image](https://user-images.githubusercontent.com/1689033/159985817-4d77e66b-d4e0-4755-9669-2cac5438b60e.png)
:(

After: 
![image](https://user-images.githubusercontent.com/1689033/159985838-bebcc787-3b93-48b5-8a9d-b551aa0bcbff.png)
:)

The Unity Input System allows automated tests to create and use "fake" devices. This can be achieved in two different ways:
- either, **as in #220**, each class that contains tests, derives from [`InputTestFixture`](https://docs.unity3d.com/Packages/com.unity.inputsystem@1.0/api/UnityEngine.InputSystem.InputTestFixture.html) directly and creates devices as needed or [a derivative thereof that sets up a predefined collection of devices](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/blob/b3e6b55b31d0cfa414c1cc45cdf6816d1f75798e/unity-ggjj/Assets/Tests/PlayModeTests/Tools/InputTestTools.cs#L14-L22)
- or **as in this PR**, each class that contains tests, creates an instance of [`InputTestFixture`](https://docs.unity3d.com/Packages/com.unity.inputsystem@1.0/api/UnityEngine.InputSystem.InputTestFixture.html) and creates devices as needed or creates [a derivative thereof that sets up a predefined collection of devices](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/blob/b3e6b55b31d0cfa414c1cc45cdf6816d1f75798e/unity-ggjj/Assets/Tests/PlayModeTests/Tools/InputTestTools.cs#L14-L22) but then [**explicitly needs to use `[SetUp]` and `[TearDown]` methods**](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/blob/6b435436bffc6e4a6ffd171c6e4888960667e49e/unity-ggjj/Assets/Tests/PlayModeTests/Scenes/MainMenu/ViaKeyboard.cs#L13-L27)

As mentioned, both approaches achieve the same goal:  
Calling `InputTestFixture.SetUp()` saves all real devices from Unity and disconnects them, so **only** fake devices exist and tests can run in isolation.  
This is required to prevent oddities caused by real input devices:

- OS-specific things like no input events if the Editor isn't focused
- mouse positions being overwritten by the real mouse cursor
- running out of devices (if fake devices are added and the 255 device threshold is crossed)
- removing real devices and the editor being unable to send any input to the game until a device is fully disconnected and reconnected

`InputTestFixture.TearDown()` re-attaches all previously known real devices and allows the user to interact with the game as normal.

**In this implementation, this is done manually. Each classes containing input tests [explicitly creates `[SetUp]` and `[TearDown]` methods where the respective methods on InputTestTools (and thereby `InputTestFixture`) are called](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/blob/6b435436bffc6e4a6ffd171c6e4888960667e49e/unity-ggjj/Assets/Tests/PlayModeTests/Scenes/MainMenu/ViaKeyboard.cs#L13-L27).**

Additionally, `StoryProgresser` and `InputTestTools` **cannot exist in parallel**:  
As both derive from `InputTestFixture` calling `SetUp()` on one, disconnects all devices of the other. Instead:
- `StoryProgresser` now derives from `InputTestTools`
- classes that use **both**, only have a `StoryProgresser` instance
- classes that **only need `InputTestTools`**, only have an `InputTestTools` instance

## Testing instructions
Follow the [`Steps to Reproduce`](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/issues/200#:~:text=headless%20using%20%2Dbatchmode.-,Steps%20To%20Reproduce,-Checkout%204d74b50%20or) of Issue #200.

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[x]` Has associated resource: 
  - closes #200
  - #220
  <!--- Include any project card, github issue, etc. associated with this PR -->
