### PR TITLE
bugfix/223-First-evidence-item-is-immediately-selected-when-presenting-evidence

### DIFF
--- a/unity-ggjj/Assets/Scripts/Evidence/EvidenceMenuItem.cs
+++ b/unity-ggjj/Assets/Scripts/Evidence/EvidenceMenuItem.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -10,7 +11,38 @@ public class EvidenceMenuItem : MonoBehaviour, ISelectHandler
 
     [SerializeField, Tooltip("The evidence menu this evidence menu item is a child of")]
     private EvidenceMenu _evidenceMenu;
+    
     private ICourtRecordObject _courtRecordObject;
+    private Selectable _selectable;
+
+    private Selectable Selectable
+    {
+        get
+        {
+            if (_selectable == null)
+            {
+                _selectable = GetComponent<Selectable>();
+            }
+
+            return _selectable;
+        }
+    }
+    
+    /// <summary>
+    /// Disable the selectable then reenable it after one frame so that menu items
+    /// aren't selected on the same frame the menu opens
+    /// </summary>
+    private void OnEnable()
+    {
+        Selectable.enabled = false;
+        StartCoroutine(EnableOnNextFrame());
+    }
+
+    private IEnumerator EnableOnNextFrame()
+    {
+        yield return null;
+        Selectable.enabled = true;
+    }
 
     /// <summary>
     /// When evidence is assigned to this menu item its Image component will be automatically updated.

--- a/unity-ggjj/Assets/Scripts/Evidence/EvidenceMenuItem.cs
+++ b/unity-ggjj/Assets/Scripts/Evidence/EvidenceMenuItem.cs
@@ -15,19 +15,8 @@ public class EvidenceMenuItem : MonoBehaviour, ISelectHandler
     private ICourtRecordObject _courtRecordObject;
     private Selectable _selectable;
 
-    private Selectable Selectable
-    {
-        get
-        {
-            if (_selectable == null)
-            {
-                _selectable = GetComponent<Selectable>();
-            }
+    private Selectable Selectable => _selectable == null ? _selectable = GetComponent<Selectable>() : _selectable;
 
-            return _selectable;
-        }
-    }
-    
     /// <summary>
     /// Disable the selectable then reenable it after one frame so that menu items
     /// aren't selected on the same frame the menu opens

--- a/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/AddRecordTest.ink
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/AddRecordTest.ink
@@ -1,5 +1,5 @@
-INCLUDE ../Macros.ink
-INCLUDE ../FailureStates.ink
+INCLUDE ../../../Resources/InkDialogueScripts/Templates/Macros.ink
+INCLUDE ../../../Resources/InkDialogueScripts/Templates/FailureStates.ink
 
 &ADD_FAILURE_SCRIPT:TMPH_FAIL_1
 


### PR DESCRIPTION
## Summary
<!--- Describe the change below, including rationale and design decisions -->
Adds a one frame delay when the evidence menu is open before buttons can be selected.
This fixes buttons being selected on the same frame the menu is opened.

## Testing instructions
<!--- What steps can be taken to manually verify the changes? -->
Open AddRecordTest.ink
Remove the line `&REMOVE_EVIDENCE:Bent_Coins`
Play the script in the Game scene.
When prompted to present evidence you should be able to present the evidence by pressing X or Enter.
The text box should say correct after you do this and NOT before.

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[ ]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->
closes #223 