### PR TITLE
"New Game" button in main menu launches `1-1` story

### DIFF
--- a/unity-ggjj/Assets/Scenes/MainMenu.unity
+++ b/unity-ggjj/Assets/Scenes/MainMenu.unity
@@ -7736,7 +7736,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 33de4f31ae9f94bf6a3ef7e8c1b64085, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _narrativeScript: {fileID: 4900000, guid: 6fb0a3af5dbc241b2bc2db1209468de1, type: 3}
+  _narrativeScript: {fileID: 4900000, guid: c2d26570bbb424d3598fa05e0d7adbaf, type: 3}
 --- !u!114 &1316906785
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
Changes the "New Game" button to start the stories added in #241.

## Testing instructions
1. Download any build from the GitHub Actions artifacts
2. Click on "New Game"
3. Notice the game playing the full main game story, instead of jumping to the Ross Cross-Examination story

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[x]` Has associated resource: 
  - #8
  <!--- Include any project card, github issue, etc. associated with this PR -->
closes #242 