### PR TITLE
bugfix/Cannot navigate main menu with keyboard after returning to main menu through pause menu

### DIFF
--- a/unity-ggjj/Assets/Scripts/Menu/Menu.cs
+++ b/unity-ggjj/Assets/Scripts/Menu/Menu.cs
@@ -69,15 +69,4 @@ public class Menu : MonoBehaviour
         }
         _initiallyHighlightedButton.Select();
     }
-
-    /// <summary>
-    /// Called when the menu is disabled. Should be used to set DialogueController to not busy.
-    /// </summary>
-    private void OnDisable()
-    {
-        if (EventSystem.current != null)
-        {
-            EventSystem.current.SetSelectedGameObject(null);
-        }
-    }
 }


### PR DESCRIPTION
## Summary
<!--- Describe the change below, including rationale and design decisions -->
Removes some code that sets the currently selected game object to null when a menu is disabled. When returning to the main menu from the pause menu the new game button would become selected, but the then pause menu would be disabled setting the currently selected game object to null.

Though I can't imagine I originally added this code for nothing, I'm not quite sure what its purpose was, so please check to see if anything is broken.

## Testing instructions
<!--- What steps can be taken to manually verify the changes? -->
Start the Game scene and go back to the main menu via the pause menu. Check that you can navigate without using the mouse.
Make sure the rest of the game still works.
Run the tests.

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[ ]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->
closes #240 