### PR TITLE
249 auto skip action does not work

### DIFF
--- a/unity-ggjj/Assets/Scenes/Game.unity
+++ b/unity-ggjj/Assets/Scenes/Game.unity
@@ -1778,7 +1778,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 33de4f31ae9f94bf6a3ef7e8c1b64085, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _narrativeScript: {fileID: 0}
+  <NarrativeScript>k__BackingField: {fileID: 0}
 --- !u!4 &606207933
 Transform:
   m_ObjectHideFlags: 0
@@ -2457,6 +2457,7 @@ MonoBehaviour:
   _narrativeGameState: {fileID: 7963640705624872190}
   _settingsMusicVolume: 0.5
   _settingsSfxVolume: 0.5
+  _defaultSong: {fileID: 0}
 --- !u!4 &2582401826076157597
 Transform:
   m_ObjectHideFlags: 0
@@ -3344,7 +3345,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 456175c2b594046d3923a6d20445dd86, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _narrativeScript: {fileID: 0}
+  _narrativeScript: {fileID: 4900000, guid: 517647837e20243bead58827aaa3547f, type: 3}
 --- !u!1 &8699442053336843567
 GameObject:
   m_ObjectHideFlags: 0
@@ -3386,33 +3387,10 @@ MonoBehaviour:
   _ignoredCharacters: 2700280029002d00
   _defaultDialogueChirpSfx: {fileID: 8300000, guid: bec396ecc7b7242499dbad1326715317, type: 3}
   _chirpEveryNthLetter: 3
+  _continueArrow: {fileID: 284323535}
   <OnLineEnd>k__BackingField:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: DialogueController, GG-JointJustice
-        m_MethodName: SetBusy
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 876025880}
-        m_TargetAssemblyTypeName: ActorController, GG-JointJustice
-        m_MethodName: StopTalking
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
       - m_Target: {fileID: 284323535}
         m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
         m_MethodName: SetActive
@@ -3425,24 +3403,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
-  _onAutoSkip:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: DialogueController, GG-JointJustice
-        m_MethodName: OnContinueStory
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-  _onLetterAppear:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!1 &9036500920682706004
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity-ggjj/Assets/Scenes/Game.unity
+++ b/unity-ggjj/Assets/Scenes/Game.unity
@@ -3388,21 +3388,6 @@ MonoBehaviour:
   _defaultDialogueChirpSfx: {fileID: 8300000, guid: bec396ecc7b7242499dbad1326715317, type: 3}
   _chirpEveryNthLetter: 3
   _continueArrow: {fileID: 284323535}
-  <OnLineEnd>k__BackingField:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 284323535}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 1
-        m_CallState: 2
 --- !u!1 &9036500920682706004
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity-ggjj/Assets/Scenes/Game.unity
+++ b/unity-ggjj/Assets/Scenes/Game.unity
@@ -3345,7 +3345,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 456175c2b594046d3923a6d20445dd86, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _narrativeScript: {fileID: 4900000, guid: 517647837e20243bead58827aaa3547f, type: 3}
+  _narrativeScript: {fileID: 0}
 --- !u!1 &8699442053336843567
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity-ggjj/Assets/Scripts/UI/AppearingDialogueController/AppearingDialogueController.cs
+++ b/unity-ggjj/Assets/Scripts/UI/AppearingDialogueController/AppearingDialogueController.cs
@@ -8,7 +8,7 @@ using UnityEngine.Serialization;
 
 public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueController
 {
-    [FormerlySerializedAs("_game")] [SerializeField] private NarrativeGameState _narrativeGameState;
+    [SerializeField] private NarrativeGameState _narrativeGameState;
 
     [Tooltip("Drag a NameBox component here.")]
     [SerializeField] private NameBox _namebox;
@@ -38,11 +38,10 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
     [Tooltip("Specify how often a chirp should play here")]
     [SerializeField] private int _chirpEveryNthLetter = 1;
 
-    
+    [SerializeField] private GameObject _continueArrow;
+
     [field:Header("Events")]
     [field:SerializeField] public UnityEvent OnLineEnd { get; private set; }
-    [SerializeField] private UnityEvent _onAutoSkip;
-    [SerializeField] private UnityEvent _onLetterAppear;
 
     private TMP_TextInfo _textInfo;
     private Coroutine _printCoroutine;
@@ -76,6 +75,7 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
         StopPrintingText();
         text = text.TrimEnd('\n');
         TextBoxHidden = false;
+        _continueArrow.SetActive(false);
 
         _narrativeGameState.ActorController.StartTalking();
         int startingIndex = 0;
@@ -130,7 +130,6 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
         for (int i = startingIndex; i < _textInfo.characterCount; i++)
         {
             _textBox.maxVisibleCharacters++;
-            _onLetterAppear.Invoke();
             var currentCharacterInfo = _textInfo.characterInfo[_textBox.maxVisibleCharacters - 1];
             TryPlayDialogueChirp(_namebox.CurrentActorDialogueChirp, currentCharacterInfo);
             yield return new WaitForSeconds(GetDelay(currentCharacterInfo));
@@ -139,10 +138,8 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
 
         if (AutoSkip)
         {
-            _onAutoSkip.Invoke();
+            _narrativeGameState.NarrativeScriptPlayerComponent.NarrativeScriptPlayer.Continue();
         }
-
-        IsPrintingText = false;
     }
 
     /// <summary>
@@ -217,7 +214,8 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
     private void EndLine()
     {
         _narrativeGameState.ActorController.StopTalking();
-        OnLineEnd.Invoke();
+        _continueArrow.SetActive(true);
+        IsPrintingText = false;
     }
 }
 

--- a/unity-ggjj/Assets/Scripts/UI/AppearingDialogueController/AppearingDialogueController.cs
+++ b/unity-ggjj/Assets/Scripts/UI/AppearingDialogueController/AppearingDialogueController.cs
@@ -40,9 +40,6 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
 
     [SerializeField] private GameObject _continueArrow;
 
-    [field:Header("Events")]
-    [field:SerializeField] public UnityEvent OnLineEnd { get; private set; }
-
     private TMP_TextInfo _textInfo;
     private Coroutine _printCoroutine;
     private int _chirpIndex;

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/AppearingDialogueController/IntegrationTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/AppearingDialogueController/IntegrationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 using Tests.PlayModeTests.Tools;
 using TMPro;
 using UnityEngine;
@@ -33,35 +34,17 @@ namespace Tests.PlayModeTests.Scripts.AppearingDialogueController
         {
             const string TEXT_TO_PRINT = "Lorem ips";
 
-            DateTime completedAt = default;
-
-            void OnLineEndUpdateCompletionTime()
-            {
-                completedAt = DateTime.Now;
-            }
-
-            TimeSpan firstDuration;
-            TimeSpan secondDuration;
-
-            _appearingDialogueController.OnLineEnd.AddListener(OnLineEndUpdateCompletionTime);
             _appearingDialogueController.CharacterDelay = 1f;
             var startedAt = DateTime.Now;
             _appearingDialogueController.PrintText(TEXT_TO_PRINT);
-            while (completedAt == default)
-            {
-                yield return new WaitForSeconds(1.0f);
-            }
-            firstDuration = completedAt - startedAt;
-            completedAt = default;
+            yield return TestTools.WaitForState(() => !_appearingDialogueController.IsPrintingText);
+            var firstDuration = DateTime.Now - startedAt;
 
             _appearingDialogueController.CharacterDelay = 0f;
             startedAt = DateTime.Now;
             _appearingDialogueController.PrintText(TEXT_TO_PRINT);
-            while (completedAt == default)
-            {
-                yield return new WaitForSeconds(1.0f);
-            }
-            secondDuration = completedAt - startedAt;
+            yield return TestTools.WaitForState(() => !_appearingDialogueController.IsPrintingText);
+            var secondDuration = DateTime.Now - startedAt;
 
             Assert.Greater(firstDuration, secondDuration);
         }
@@ -69,35 +52,20 @@ namespace Tests.PlayModeTests.Scripts.AppearingDialogueController
         [UnityTest]
         public IEnumerator AppearInstantlyImpactsTimeUntilOnLineEndEventIsFired()
         {
-            DateTime completedAt = default;
-
-            void OnLineEndUpdateCompletionTime()
-            {
-                completedAt = DateTime.Now;
-            }
-
             TimeSpan firstDuration;
             TimeSpan secondDuration;
 
-            _appearingDialogueController.OnLineEnd.AddListener(OnLineEndUpdateCompletionTime);
             _appearingDialogueController.AppearInstantly = false;
             var startedAt = DateTime.Now;
             _appearingDialogueController.PrintText(TEST_TEXT);
-            while (completedAt == default)
-            {
-                yield return new WaitForSeconds(1.0f);
-            }
-            firstDuration = completedAt - startedAt;
-            completedAt = default;
+            yield return TestTools.WaitForState(() => !_appearingDialogueController.IsPrintingText);
+            firstDuration = DateTime.Now - startedAt;
 
             _appearingDialogueController.AppearInstantly = true;
             startedAt = DateTime.Now;
             _appearingDialogueController.PrintText(TEST_TEXT);
-            while (completedAt == default)
-            {
-                yield return new WaitForSeconds(1.0f);
-            }
-            secondDuration = completedAt - startedAt;
+            yield return TestTools.WaitForState(() => !_appearingDialogueController.IsPrintingText);
+            secondDuration = DateTime.Now - startedAt;
 
             Assert.Greater(firstDuration, secondDuration);
         }

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/AppearingDialogueController/IntegrationTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/AppearingDialogueController/IntegrationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using NUnit.Framework;
 using Tests.PlayModeTests.Tools;
+using TMPro;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
@@ -135,6 +136,41 @@ namespace Tests.PlayModeTests.Scripts.AppearingDialogueController
             _appearingDialogueController.TextBoxHidden = true;
             Assert.IsFalse(nameBox.activeSelf);
             yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator TextCanBeAutoSkipped()
+        {
+            var storyProgresser = new StoryProgresser();
+            storyProgresser.Setup();
+            TestTools.StartGame("AutoSkipTest");
+            var narrativeScriptPlayer = Object.FindObjectOfType<NarrativeGameState>().NarrativeScriptPlayerComponent.NarrativeScriptPlayer;
+            
+            yield return TestTools.WaitForState(() => !_appearingDialogueController.IsPrintingText);
+            var dialogueText = GameObject.Find("Dialogue").GetComponent<TextMeshProUGUI>();
+            Assert.AreEqual("Start of test", dialogueText.text);
+            narrativeScriptPlayer.Continue();
+            yield return TestTools.WaitForState(() => !_appearingDialogueController.IsPrintingText);
+            Assert.AreEqual("End of test", dialogueText.text);
+        }
+
+        [UnityTest]
+        public IEnumerator ContinueArrowAppearsWhenTextIsPrinting()
+        {
+            var storyProgresser = new StoryProgresser();
+            storyProgresser.Setup();
+            TestTools.StartGame("AutoSkipTest");
+            var narrativeScriptPlayer = Object.FindObjectOfType<NarrativeGameState>().NarrativeScriptPlayerComponent.NarrativeScriptPlayer;
+            var continueArrow = GameObject.Find("ContinueArrow");
+
+            Assert.IsFalse(_appearingDialogueController.IsPrintingText);
+            Assert.IsTrue(continueArrow.activeInHierarchy);
+
+            narrativeScriptPlayer.Continue();
+            Assert.IsFalse(continueArrow.activeInHierarchy);
+            
+            yield return TestTools.WaitForState(() => !_appearingDialogueController.IsPrintingText);
+            Assert.IsTrue(continueArrow.activeInHierarchy);
         }
     }
 }

--- a/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/AutoSkipTest.ink
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/AutoSkipTest.ink
@@ -1,6 +1,6 @@
+&APPEAR_INSTANTLY
+Start of test
 &AUTO_SKIP:True
 Test line
-Test line
 &AUTO_SKIP:False
-Test line
-Final line
+End of test

--- a/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/AutoSkipTest.ink
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/AutoSkipTest.ink
@@ -1,0 +1,6 @@
+&AUTO_SKIP:True
+Test line
+Test line
+&AUTO_SKIP:False
+Test line
+Final line

--- a/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/AutoSkipTest.ink.meta
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/AutoSkipTest.ink.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 867009d89e48c48a392b6b88555307e5
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/AutoSkipTest.json
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/AutoSkipTest.json
@@ -1,0 +1,1 @@
+﻿{"inkVersion":20,"root":[["^&AUTO_SKIP:True","\n","^Test line","\n","^Test line","\n","^&AUTO_SKIP:False","\n","^Test line","\n","^Final line","\n",["done",{"#f":5,"#n":"g-0"}],null],"done",{"#f":1}],"listDefs":{}}

--- a/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/AutoSkipTest.json
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/AutoSkipTest.json
@@ -1,1 +1,1 @@
-﻿{"inkVersion":20,"root":[["^&AUTO_SKIP:True","\n","^Test line","\n","^Test line","\n","^&AUTO_SKIP:False","\n","^Test line","\n","^Final line","\n",["done",{"#f":5,"#n":"g-0"}],null],"done",{"#f":1}],"listDefs":{}}
+﻿{"inkVersion":20,"root":[["^&APPEAR_INSTANTLY","\n","^Start of test","\n","^&AUTO_SKIP:True","\n","^Test line","\n","^&AUTO_SKIP:False","\n","^End of test","\n",["done",{"#f":5,"#n":"g-0"}],null],"done",{"#f":1}],"listDefs":{}}

--- a/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/AutoSkipTest.json.meta
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/AutoSkipTest.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 517647837e20243bead58827aaa3547f
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
<!--- Describe the change below, including rationale and design decisions -->
Fixes the bug described in #249.
Removes UnityEvents from AppearingDialogueController in favour of direct references.
Adds some tests for the auto-skip action and the continue arrow.

## Testing instructions
<!--- What steps can be taken to manually verify the changes? -->
Play 1-4-JoryWitnessTestimony. Notice how the game autoskips when Tutorial Boy says "Witness, state y-".
Run the associated tests.

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[x]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->
closes #249 