### PR TITLE
Auto create PRs for outdated GitHub Actions and docs generator dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,4 @@ updates:
     schedule:
       interval: "daily"
       time: "04:00"
-    labels:
-      - "autoupdate"
     open-pull-requests-limit: 100

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "03:00"
+    open-pull-requests-limit: 100
+
+  - package-ecosystem: "nuget"
+    directory: "/docs_generator"
+    schedule:
+      interval: "daily"
+      time: "04:00"
+    labels:
+      - "autoupdate"
+    open-pull-requests-limit: 100


### PR DESCRIPTION
## Summary
Dependabot can automatically create Pull Requests for outdated dependencies inside both...
- the docs generator .NET NuGet packages **_and_**
- GitHub Actions

It will run through the normal PR flow, so builds are run and docs are generated automatically. The PR then will show, if updates introduce any breaking changes.

I usually set it up for any projects I have on GitHub, so I figured it might be a good idea here too:
- https://github.com/ViMaSter/unity-version-bump/pulls?q=is%3Apr+is%3Aclosed
- https://github.com/ViMaSter/gdqreminder-backend/pulls?q=is%3Apr+is%3Aclosed
- https://github.com/ViMaSter/gdqreminder-mobile/pulls?q=is%3Apr+is%3Aclosed

## Testing instructions
1. [Check out my fork's pull requests](https://github.com/ViMaSter/GG-JointJustice-Unity/pulls)
2. See if that's something might want 👀

## Setup
After merging this PR (or before), there are a few steps needed to activate Dependabot:
1. Visit https://github.com/Studio-Lovelies/GG-JointJustice-Unity/settings/security_analysis
2. Enable `Dependabot security updates`
3. Enable `Dependabot version updates`

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[ ]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->
