### PR TITLE
Allow dependabot to set Unity tests as successful in created PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,10 @@ jobs:
     needs: [checkLicense]
     if: needs.checkLicense.outputs.is_unity_serial_set == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      checks: write # allows dependabot PRs to set pull request checks
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -127,6 +131,10 @@ jobs:
     needs: [checkLicense]
     if: needs.checkLicense.outputs.is_unity_serial_set == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      checks: write # allows dependabot PRs to set pull request checks
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -180,6 +188,10 @@ jobs:
     needs: [checkLicense]
     if: needs.checkLicense.outputs.is_unity_serial_set == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      checks: write # allows dependabot PRs to set pull request checks
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
## Summary
Dependabot runs are [treated like PRs from forks](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/). Hence, they lack all write-permissions on this repository by default.

This includes setting checks (i.e. whether or not a test run was successful or not) and results in [the inability for Dependabot to change required test checks to "passed"](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/runs/7170957547?check_suite_focus=true
).
![image](https://user-images.githubusercontent.com/1689033/177056018-a0c06329-cf86-4423-bda4-61ff4a9a366d.png)

## Testing instructions
1. Notice failing dependabot PR checks: https://github.com/Studio-Lovelies/GG-JointJustice-Unity/runs/7170957547?check_suite_focus=true
2. Check that, [after the change inside this PR](https://github.com/ViMaSter/GG-JointJustice-Unity/commit/76314ef986a295684535b1fed8100079accae8dd), they work on my fork: https://github.com/ViMaSter/GG-JointJustice-Unity/runs/7171216355?check_suite_focus=true
3. ...nothing really testable until then. 👀

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[ ]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->
