### PR TITLE
Reintroduce text speedup inside `AppearingDialogueController`

### DIFF
--- a/unity-ggjj/Assets/Scenes/Game.unity
+++ b/unity-ggjj/Assets/Scenes/Game.unity
@@ -422,22 +422,6 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
-  - _inputActionReference: {fileID: 2662257130399901586, guid: 3b3ca44a1d04d4c5c847c1b48fb83536, type: 3}
-    _event:
-      m_PersistentCalls:
-        m_Calls:
-        - m_Target: {fileID: 8054490722184616645}
-          m_TargetAssemblyTypeName: NarrativeScriptPlayerComponent, GG-JointJustice
-          m_MethodName: Continue
-          m_Mode: 1
-          m_Arguments:
-            m_ObjectArgument: {fileID: 0}
-            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-            m_IntArgument: 0
-            m_FloatArgument: 0
-            m_StringArgument: 
-            m_BoolArgument: 0
-          m_CallState: 2
   - _inputActionReference: {fileID: 675183000856290462, guid: 3b3ca44a1d04d4c5c847c1b48fb83536, type: 3}
     _event:
       m_PersistentCalls:
@@ -461,6 +445,38 @@ MonoBehaviour:
           m_Arguments:
             m_ObjectArgument: {fileID: 4398871484667759689}
             m_ObjectArgumentAssemblyTypeName: Input.InputModule, GG-JointJustice
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - _inputActionReference: {fileID: 6117326585994252875, guid: 3b3ca44a1d04d4c5c847c1b48fb83536, type: 3}
+    _event:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 8054490722184616645}
+          m_TargetAssemblyTypeName: NarrativeScriptPlayerComponent, GG-JointJustice
+          m_MethodName: ToggleSpeedup
+          m_Mode: 0
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - _inputActionReference: {fileID: 2662257130399901586, guid: 3b3ca44a1d04d4c5c847c1b48fb83536, type: 3}
+    _event:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 8054490722184616645}
+          m_TargetAssemblyTypeName: NarrativeScriptPlayerComponent, GG-JointJustice
+          m_MethodName: Continue
+          m_Mode: 1
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
             m_IntArgument: 0
             m_FloatArgument: 0
             m_StringArgument: 
@@ -4213,7 +4229,8 @@ MonoBehaviour:
   _speechPanel: {fileID: 641077}
   <CharacterDelay>k__BackingField: 0.02
   <DefaultPunctuationDelay>k__BackingField: 0.25
-  _punctuationDelay:
+  <SpeedupDelay>k__BackingField: 0
+  _specialDelays:
   - <Item1>k__BackingField: 44
     <Item2>k__BackingField: 0.1
   _ignoredCharacters: 2700280029002d00

--- a/unity-ggjj/Assets/Scripts/Input/Control.cs
+++ b/unity-ggjj/Assets/Scripts/Input/Control.cs
@@ -9,7 +9,7 @@ namespace Input
     public class Control
     {
         [SerializeField] private InputActionReference _inputActionReference;
-        [SerializeField] private UnityEvent _event;
+        [SerializeField] private UnityEvent<InputAction.CallbackContext> _event;
 
         public void Enable()
         {
@@ -17,9 +17,9 @@ namespace Input
             _inputActionReference.action.Enable();
         }
 
-        public void Invoke(InputAction.CallbackContext ctx)
+        public void Invoke(InputAction.CallbackContext inputCallbackContext)
         {
-            _event.Invoke();
+            _event.Invoke(inputCallbackContext);
         }
 
         public void Disable()

--- a/unity-ggjj/Assets/Scripts/Input/Controls.inputactions
+++ b/unity-ggjj/Assets/Scripts/Input/Controls.inputactions
@@ -6,6 +6,14 @@
             "id": "de1537fe-4eb2-4289-b2fb-a49589bc443e",
             "actions": [
                 {
+                    "name": "ToggleTextSpeedup",
+                    "type": "Button",
+                    "id": "73cf0c6d-7a5f-4586-b850-5726b955b4f5",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
                     "name": "Left Mouse Button",
                     "type": "PassThrough",
                     "id": "39ed1286-0cce-4d62-b445-81e4f9eb7e5f",
@@ -63,6 +71,17 @@
                 }
             ],
             "bindings": [
+                {
+                    "name": "",
+                    "id": "7811c9e1-b05e-4dfb-8c46-8d3fc0e8d035",
+                    "path": "<Keyboard>/x",
+                    "interactions": "Press(behavior=2)",
+                    "processors": "",
+                    "groups": "Mouse and Keyboard",
+                    "action": "ToggleTextSpeedup",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
                 {
                     "name": "",
                     "id": "988ad8b7-96bd-45d0-a79f-b8fd62a8d7a9",

--- a/unity-ggjj/Assets/Scripts/NarrativeScript/NarrativeScriptPlayer/INarrativeScriptPlayer.cs
+++ b/unity-ggjj/Assets/Scripts/NarrativeScript/NarrativeScriptPlayer/INarrativeScriptPlayer.cs
@@ -1,3 +1,5 @@
+using UnityEngine.InputSystem;
+
 public interface INarrativeScriptPlayer
 {
     INarrativeScript ActiveNarrativeScript { get; set; }
@@ -5,6 +7,7 @@ public interface INarrativeScriptPlayer
     bool Waiting { get; set; }
     bool CanPressWitness { get; }
     bool HasSubStory { get; }
+    void ToggleSpeedup(InputAction.CallbackContext inputCallbackContext);
     
     void Continue(bool overridePrintingText = false);
     void HandleChoice(int choiceIndex);

--- a/unity-ggjj/Assets/Scripts/NarrativeScript/NarrativeScriptPlayer/NarrativeScriptPlayer.cs
+++ b/unity-ggjj/Assets/Scripts/NarrativeScript/NarrativeScriptPlayer/NarrativeScriptPlayer.cs
@@ -1,9 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Linq;
-using Codice.Client.Commands;
 using Ink.Runtime;
-using UnityEngine;
 using UnityEngine.InputSystem;
 
 /// <summary>

--- a/unity-ggjj/Assets/Scripts/NarrativeScript/NarrativeScriptPlayer/NarrativeScriptPlayer.cs
+++ b/unity-ggjj/Assets/Scripts/NarrativeScript/NarrativeScriptPlayer/NarrativeScriptPlayer.cs
@@ -1,8 +1,10 @@
 using System;
 using System.ComponentModel;
 using System.Linq;
+using Codice.Client.Commands;
 using Ink.Runtime;
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 /// <summary>
 /// Acts a wrapper around Ink stories, providing access to each new line in a Story
@@ -75,6 +77,29 @@ public class NarrativeScriptPlayer : INarrativeScriptPlayer
     public NarrativeScriptPlayer(INarrativeGameState narrativeGameState)
     {
         _narrativeGameState = narrativeGameState;
+    }
+
+    
+    /// <summary>
+    /// Speeds up or restores the previous speed of delay between characters when called
+    /// </summary>
+    /// <param name="inputCallbackContext">Generated from Unity's InputModule</param>
+    public void ToggleSpeedup(InputAction.CallbackContext inputCallbackContext)
+    {
+        if (inputCallbackContext.ReadValueAsButton())
+        {
+            // this check is required, as the "speedup" button is identical to the "progress story button".
+            // removal would result in tiny sub-second speedups, each time the player attempts to
+            // progress the narrative script.
+            // with it, the speedup only occurs if the button is pressed while there is still text left
+            // to show in the current line of dialogue
+            if (_narrativeGameState.AppearingDialogueController.IsPrintingText)
+            {
+                _narrativeGameState.AppearingDialogueController.SpeedupText = true;
+                return;
+            }
+        }
+        _narrativeGameState.AppearingDialogueController.SpeedupText = false;
     }
 
     /// <summary>

--- a/unity-ggjj/Assets/Scripts/NarrativeScript/NarrativeScriptPlayer/NarrativeScriptPlayerComponent.cs
+++ b/unity-ggjj/Assets/Scripts/NarrativeScript/NarrativeScriptPlayer/NarrativeScriptPlayerComponent.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 public class NarrativeScriptPlayerComponent : MonoBehaviour, INarrativeScriptPlayerComponent
 {
@@ -34,6 +35,11 @@ public class NarrativeScriptPlayerComponent : MonoBehaviour, INarrativeScriptPla
     public void Continue()
     {
         NarrativeScriptPlayer.Continue();
+    }
+
+    public void ToggleSpeedup(InputAction.CallbackContext inputCallbackContext)
+    {
+        NarrativeScriptPlayer.ToggleSpeedup(inputCallbackContext);
     }
 
     /// <summary>

--- a/unity-ggjj/Assets/Scripts/UI/AppearingDialogueController/IAppearingDialogueController.cs
+++ b/unity-ggjj/Assets/Scripts/UI/AppearingDialogueController/IAppearingDialogueController.cs
@@ -1,5 +1,6 @@
 public interface IAppearingDialogueController
 {
+    bool SpeedupText { get; set; }
     float CharacterDelay { get; set; }
     float DefaultPunctuationDelay { set; }
     bool SkippingDisabled { get; set; }

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scenes/NarrativeScripts/Case1Tests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scenes/NarrativeScripts/Case1Tests.cs
@@ -55,7 +55,8 @@ namespace Tests.PlayModeTests.Scenes.NarrativeScripts
             while (true)
             {
                 _appearingDialogueController.AppearInstantly = true;
-                _appearingDialogueController.SpeedMultiplier = 20;
+                _appearingDialogueController.SpeedupText = true;
+                _appearingDialogueController.SpeedupDelay = 0;
 
                 // If the narrative script has changed then we have reached the end of a script
                 if (NarrativeScriptHasChanged(_narrativeScript))
@@ -179,7 +180,7 @@ namespace Tests.PlayModeTests.Scenes.NarrativeScripts
             if (!input.enabled) { yield break; }
             
             yield return TestTools.WaitForState(() => !_narrativeGameState.AppearingDialogueController.IsPrintingText);
-            _appearingDialogueController.SpeedMultiplier = 1;
+            _appearingDialogueController.SpeedupText = false;
             _narrativeGameState.NarrativeScriptPlayerComponent.NarrativeScriptPlayer.Continue();
         }
     }

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/AppearingDialogueController/GetDelay.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/AppearingDialogueController/GetDelay.cs
@@ -1,4 +1,6 @@
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
 using TMPro;
@@ -13,16 +15,22 @@ namespace Tests.PlayModeTests.Scripts.AppearingDialogueController
     /// </summary>
     public class GetDelay
     {
-        private const float SPEED_MULTIPLIER = 2;
-
         private static readonly char[] RegularCharacters = "The quick brown fox jumps over the lazy dog$^+|=".ToCharArray();
         private const float REGULAR_CHARACTER_SPEED = 5;
 
         private static readonly char[] PunctuationCharacters = "!@#%&*_}\"{:;[\\]".ToCharArray();
         private const float PUNCTUATION_CHARACTER_SPEED = 6;
-        private static readonly char[] IgnoredCharacters = "'()-".ToCharArray(); // treated as regular characters
 
-        private static readonly object[][] PunctuationDelays = { new object[]{',', 0.1f}};
+        private static readonly char[] IgnoredCharacters = "'()-".ToCharArray(); // treated as regular characters
+        private static readonly object[][] PunctuationDelays = { new object[] { ',', 0.1f } }; // edge-case
+
+        private static readonly object[] CharactersAndSpeed = new IEnumerable<object>[]
+        {
+            RegularCharacters.Select(character => new object[]{character, REGULAR_CHARACTER_SPEED}),
+            PunctuationCharacters.Select(character => new object[] { character, PUNCTUATION_CHARACTER_SPEED }),
+            IgnoredCharacters.Select(character => new object[] { character, REGULAR_CHARACTER_SPEED }),
+            PunctuationDelays
+        }.SelectMany(a=>a).ToArray();
 
         private global::AppearingDialogueController _appearingDialogueController;
 
@@ -37,7 +45,10 @@ namespace Tests.PlayModeTests.Scripts.AppearingDialogueController
             if (_performedOneTimeSetup)
             {
                 _appearingDialogueController.SkippingDisabled = default;
-                _appearingDialogueController.SpeedMultiplier = SPEED_MULTIPLIER;
+                _appearingDialogueController.SpeedupText = default;
+                _appearingDialogueController.SpeedupDelay = 0;
+                _appearingDialogueController.CharacterDelay = REGULAR_CHARACTER_SPEED;
+                _appearingDialogueController.DefaultPunctuationDelay = PUNCTUATION_CHARACTER_SPEED;
                 yield break;
             }
 
@@ -59,11 +70,10 @@ namespace Tests.PlayModeTests.Scripts.AppearingDialogueController
             yield return new WaitForEndOfFrame();
 
             // create controller component
-            _appearingDialogueController = gameObjectInstance.AddComponent<global::AppearingDialogueController>();
             LogAssert.Expect(LogType.Exception, "NullReferenceException: Object reference not set to an instance of an object");
+            _appearingDialogueController = gameObjectInstance.AddComponent<global::AppearingDialogueController>();
             _appearingDialogueController.CharacterDelay = REGULAR_CHARACTER_SPEED;
             _appearingDialogueController.DefaultPunctuationDelay = PUNCTUATION_CHARACTER_SPEED;
-            _appearingDialogueController.SpeedMultiplier = SPEED_MULTIPLIER;
 
             // set private properties needed for these tests to run
             var so = new SerializedObject(_appearingDialogueController);
@@ -77,7 +87,7 @@ namespace Tests.PlayModeTests.Scripts.AppearingDialogueController
                 ignoredItemsReference.GetArrayElementAtIndex(i).intValue = IgnoredCharacters[i];
             }
 
-            var punctuationDelaysReference = so.FindProperty("_punctuationDelay");
+            var punctuationDelaysReference = so.FindProperty("_specialDelays");
             for (var i = 0; i < PunctuationDelays.Length; i++)
             {
                 punctuationDelaysReference.InsertArrayElementAtIndex(i);
@@ -104,77 +114,62 @@ namespace Tests.PlayModeTests.Scripts.AppearingDialogueController
         [Test]
         public void VerifyRegularCharacterSpeed(char character)
         {
-            Assert.AreEqual(REGULAR_CHARACTER_SPEED / SPEED_MULTIPLIER, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
-            _appearingDialogueController.SpeedMultiplier = SPEED_MULTIPLIER * 2;
-            Assert.AreEqual(REGULAR_CHARACTER_SPEED / (SPEED_MULTIPLIER * 2), _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
+            Assert.AreEqual(REGULAR_CHARACTER_SPEED, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
+            _appearingDialogueController.CharacterDelay = REGULAR_CHARACTER_SPEED * 2;
+            Assert.AreEqual(REGULAR_CHARACTER_SPEED * 2, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
         }
 
         [TestCaseSource(nameof(PunctuationCharacters))]
         [Test]
         public void VerifyPunctuationCharacterSpeed(char character)
         {
-            Assert.AreEqual(PUNCTUATION_CHARACTER_SPEED / SPEED_MULTIPLIER, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
-            _appearingDialogueController.SpeedMultiplier = SPEED_MULTIPLIER * 2;
-            Assert.AreEqual(PUNCTUATION_CHARACTER_SPEED / (SPEED_MULTIPLIER * 2), _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
+            Assert.AreEqual(PUNCTUATION_CHARACTER_SPEED, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
+            _appearingDialogueController.DefaultPunctuationDelay = PUNCTUATION_CHARACTER_SPEED * 2;
+            Assert.AreEqual(PUNCTUATION_CHARACTER_SPEED * 2, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
         }
 
         [TestCaseSource(nameof(IgnoredCharacters))]
         [Test]
         public void VerifyIgnoredCharacterSpeed(char character)
         {
-            Assert.AreEqual(REGULAR_CHARACTER_SPEED / SPEED_MULTIPLIER, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
-            _appearingDialogueController.SpeedMultiplier = SPEED_MULTIPLIER * 2;
-            Assert.AreEqual(REGULAR_CHARACTER_SPEED / (SPEED_MULTIPLIER * 2), _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
+            Assert.AreEqual(REGULAR_CHARACTER_SPEED, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
+            _appearingDialogueController.CharacterDelay = REGULAR_CHARACTER_SPEED * 2;
+            Assert.AreEqual(REGULAR_CHARACTER_SPEED * 2, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
         }
 
         [TestCaseSource(nameof(PunctuationDelays))]
         [Test]
-        public void VerifyPunctuationDelays(char character, float expectedDelay)
+        public void VerifySpecialDelays(char character, float expectedDelay)
         {
-            Assert.AreEqual(expectedDelay / SPEED_MULTIPLIER, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
-            _appearingDialogueController.SpeedMultiplier = SPEED_MULTIPLIER * 2;
-            Assert.AreEqual(expectedDelay / (SPEED_MULTIPLIER * 2), _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
-        }
-
-        [TestCaseSource(nameof(RegularCharacters))]
-        [Test]
-        public void VerifyRegularCharacterSpeedWithDisabledSkipping(char character)
-        {
-            _appearingDialogueController.SkippingDisabled = true;
-            Assert.AreEqual(REGULAR_CHARACTER_SPEED, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
-            _appearingDialogueController.SpeedMultiplier = SPEED_MULTIPLIER * 2;
-            Assert.AreEqual(REGULAR_CHARACTER_SPEED, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
-        }
-
-        [TestCaseSource(nameof(PunctuationCharacters))]
-        [Test]
-        public void VerifyPunctuationCharacterSpeedWithDisabledSkipping(char character)
-        {
-            _appearingDialogueController.SkippingDisabled = true;
-            Assert.AreEqual(PUNCTUATION_CHARACTER_SPEED, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
-            _appearingDialogueController.SpeedMultiplier = SPEED_MULTIPLIER * 2;
-            Assert.AreEqual(PUNCTUATION_CHARACTER_SPEED, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
-        }
-
-        [TestCaseSource(nameof(IgnoredCharacters))]
-        [Test]
-        public void VerifyIgnoredCharacterSpeedWithDisabledSkipping(char character)
-        {
-            _appearingDialogueController.SkippingDisabled = true;
-            Assert.AreEqual(REGULAR_CHARACTER_SPEED, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
-            _appearingDialogueController.SpeedMultiplier = SPEED_MULTIPLIER * 2;
-            Assert.AreEqual(REGULAR_CHARACTER_SPEED, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
-        }
-
-
-        [TestCaseSource(nameof(PunctuationDelays))]
-        [Test]
-        public void VerifyPunctuationDelaysWithDisabledSkipping(char character, float expectedDelay)
-        {
-            _appearingDialogueController.SkippingDisabled = true;
             Assert.AreEqual(expectedDelay, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
-            _appearingDialogueController.SpeedMultiplier = SPEED_MULTIPLIER * 2;
+            _appearingDialogueController.CharacterDelay = REGULAR_CHARACTER_SPEED * 2;
+            _appearingDialogueController.DefaultPunctuationDelay = PUNCTUATION_CHARACTER_SPEED * 2;
             Assert.AreEqual(expectedDelay, _appearingDialogueController.GetDelay(new TMP_CharacterInfo{character=character}));
+        }
+
+        [TestCaseSource(nameof(CharactersAndSpeed))]
+        [Test]
+        public void VerifySpeedupWorksWithEveryCharacter(char character, float delayInSeconds)
+        {
+            const int SPEEDUP_IN_SECONDS = 100;
+            Assert.AreEqual(delayInSeconds, _appearingDialogueController.GetDelay(new TMP_CharacterInfo { character = character }));
+            _appearingDialogueController.SpeedupDelay = SPEEDUP_IN_SECONDS;
+            Assert.AreEqual(delayInSeconds, _appearingDialogueController.GetDelay(new TMP_CharacterInfo { character = character }));
+            _appearingDialogueController.SpeedupText = true; // speedup ignores all character types
+            Assert.AreEqual(SPEEDUP_IN_SECONDS, _appearingDialogueController.GetDelay(new TMP_CharacterInfo { character = character }));
+        }
+
+        [TestCaseSource(nameof(CharactersAndSpeed))]
+        [Test]
+        public void VerifySpeedupOnlyWorksWhenSkippingIsNotDisabled(char character, float delayInSeconds)
+        {
+            const int SPEEDUP_IN_SECONDS = 100;
+            Assert.AreEqual(delayInSeconds, _appearingDialogueController.GetDelay(new TMP_CharacterInfo { character = character }));
+            _appearingDialogueController.SpeedupDelay = SPEEDUP_IN_SECONDS;
+            Assert.AreEqual(delayInSeconds, _appearingDialogueController.GetDelay(new TMP_CharacterInfo { character = character }));
+            _appearingDialogueController.SpeedupText = true;
+            _appearingDialogueController.SkippingDisabled = true;
+            Assert.AreEqual(delayInSeconds, _appearingDialogueController.GetDelay(new TMP_CharacterInfo { character = character }));
         }
     }
 }


### PR DESCRIPTION
## Summary
After integrating this PR, text can be sped up by holding down "X" while characters of the current line are being displayed. (This last worked inside 7e80bd906fe3947ae150073b7576a8a6af02df87.)

⚠ NOTE: ⚠ I've set the delay when holding down "X" to `0s` for testing purposes. We might want to change this(?). If anyone wants to do it as part of this PR, feel free to just add a commit. Otherwise I'll ping the designers after it's integrated into `develop`. I'm not entirely sure which value feels right here.
![image](https://user-images.githubusercontent.com/1689033/189540469-f91e5d8d-79ba-45eb-b26d-56d33a906897.png)

## Before/after screenshots and/or animated gif
### Before
https://user-images.githubusercontent.com/1689033/189540347-4401b9c2-5533-48b3-ada3-7d0adbe015d7.mp4
### After
https://user-images.githubusercontent.com/1689033/189540309-15e6d32f-3eea-4257-83d5-3c8b9f5bf1b6.mp4

## Testing instructions
1. Start a new game
2. Wait for a line of text to appear
3. Press and hold `X`
4. Notice the decreased character delay

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[x]` Has associated resource: #282 
