### PR TITLE
Migrate `docs_generator` from .NET 6 to .NET 7 + address deprecation of `save-state` and `set-output` commands inside related GitHub Actions

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Generate current state of docs
         id: currentDocs
-        run: echo "::set-output name=hash::$(find docs/ -type f -exec md5sum {} \; | md5sum)"
+        run: echo "hash=$(find docs/ -type f -exec md5sum {} \; | md5sum)" >> $GITHUB_OUTPUT
         
       - name: Clear /docs folder
         working-directory: ./
@@ -41,7 +41,7 @@ jobs:
 
       - name: Generate new state of docs
         id: newDocs
-        run: echo "::set-output name=hash::$(find docs/ -type f -exec md5sum {} \; | md5sum)"
+        run: echo "hash=$(find docs/ -type f -exec md5sum {} \; | md5sum)" >> $GITHUB_OUTPUT
 
       - name: Check if current and new state of docs are different
         run: echo "Current '${{ steps.currentDocs.outputs.hash }}' - New '${{ steps.newDocs.outputs.hash }}'"

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '7.0.x'
       
       - name: Build docs generator
         working-directory: ./docs_generator
@@ -37,7 +37,7 @@ jobs:
        
       - name: Execute docs runner 
         working-directory: ./unity-ggjj
-        run: ../docs_generator/bin/Debug/net6.0/Scanner
+        run: ../docs_generator/bin/Debug/net7.0/Scanner
 
       - name: Generate new state of docs
         id: newDocs

--- a/docs_generator/Scanner.csproj
+++ b/docs_generator/Scanner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <StartupObject>Scanner.Scanner</StartupObject>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
Microsoft [released .NET 7 in November](https://devblogs.microsoft.com/dotnet/announcing-dotnet-7/). There's various [performance improvements](https://devblogs.microsoft.com/dotnet/performance_improvements_in_net_7/), plus being up-to-date is just nice. :)

Low-hanging fruit: The first commit of this branch also addresses [the deprecation of `save-state` and `set-output` commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) inside the docs generator action.  
The ones inside the game build actions are handled inside #321.

## Testing instructions
1. Run the [`Generate documentation` action](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/actions/workflows/generate_docs.yml) using this branch
2. Wait for success and no changes to the documentation, compared to a run using .NET 6

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[ ]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->
