### PR TITLE
RELOAD_SCENE action now restarts the player from the currently active script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           testMode: EditMode
           checkName: Test Results - EditMode
-          customParameters: -debugCodeOptimization -enableCodeCoverage -coverageResultsPath ./coverage-results -coverageOptions generateAdditionalMetrics;assemblyFilters:+GG-JointJustice
+          coverageOptions: generateAdditionalMetrics;assemblyFilters:+GG-JointJustice
 
       - name: Upload XML report to Codecov
         uses: codecov/codecov-action@v3
@@ -117,7 +117,7 @@ jobs:
           name: EditMode
           flags: EditMode
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: unity-ggjj/coverage-results/**/*.xml
+          files: CodeCoverage/**/*.xml
 
       - name: Store test artifacts
         uses: actions/upload-artifact@v3
@@ -165,7 +165,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           testMode: PlayMode
           checkName: Test Results - PlayMode Scripts
-          customParameters: -debugCodeOptimization -enableCodeCoverage -coverageResultsPath ./coverage-results -coverageOptions generateAdditionalMetrics;assemblyFilters:+GG-JointJustice
+          coverageOptions: generateAdditionalMetrics;assemblyFilters:+GG-JointJustice
 
       - name: Upload XML report to Codecov
         uses: codecov/codecov-action@v3
@@ -174,7 +174,7 @@ jobs:
           name: PlayMode Scripts
           flags: PlayModeScripts
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: unity-ggjj/coverage-results/**/*.xml
+          files: CodeCoverage/**/*.xml
 
       - name: Store test artifacts
         uses: actions/upload-artifact@v3
@@ -222,7 +222,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           testMode: PlayMode
           checkName: Test Results - PlayMode Scenes
-          customParameters: -debugCodeOptimization -enableCodeCoverage -coverageResultsPath ./coverage-results -coverageOptions generateAdditionalMetrics;assemblyFilters:+GG-JointJustice
+          coverageOptions: generateAdditionalMetrics;assemblyFilters:+GG-JointJustice
 
       - name: Upload XML report to Codecov
         uses: codecov/codecov-action@v3
@@ -231,7 +231,7 @@ jobs:
           name: PlayMode Scenes
           flags: PlayModeScenes
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: unity-ggjj/coverage-results/**/*.xml
+          files: CodeCoverage/**/*.xml
 
       - name: Store test artifacts
         uses: actions/upload-artifact@v3
@@ -279,7 +279,7 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           testMode: PlayMode
           checkName: Test Results - PlayMode Playthrough
-          customParameters: -debugCodeOptimization -enableCodeCoverage -coverageResultsPath ./coverage-results -coverageOptions generateAdditionalMetrics;assemblyFilters:+GG-JointJustice
+          coverageOptions: generateAdditionalMetrics;assemblyFilters:+GG-JointJustice
 
       - name: Upload XML report to Codecov
         uses: codecov/codecov-action@v3
@@ -288,7 +288,7 @@ jobs:
           name: PlayMode Playthrough
           flags: PlayModePlaythrough
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: unity-ggjj/coverage-results/**/*.xml
+          files: CodeCoverage/**/*.xml
 
       - name: Store test artifacts
         uses: actions/upload-artifact@v3

--- a/unity-ggjj/Assets/Scenes/Game.unity
+++ b/unity-ggjj/Assets/Scenes/Game.unity
@@ -3538,7 +3538,7 @@ MonoBehaviour:
   _fullscreenAnimationPlayer: {fileID: 5742514839461138707}
   _objectShaker: {fileID: 4590349130768267613}
   _shoutPlayer: {fileID: 2741667134342495778}
-  _sceneLoader: {fileID: 0}
+  _sceneLoader: {fileID: 606207932}
   _witnessTestimonySign: {fileID: 2114217580}
 --- !u!4 &2044061590
 Transform:

--- a/unity-ggjj/Assets/Scripts/BGScenes/SceneController.cs
+++ b/unity-ggjj/Assets/Scripts/BGScenes/SceneController.cs
@@ -308,12 +308,12 @@ public class SceneController : MonoBehaviour, ISceneController
     }
 
     /// <summary>
-    /// Forces a scene reload.
+    /// Reloads the scene and starts it from the current root narrative script (thereby ignoring any sub-stories the main NarrativeScriptPlayer might be running)
     /// Called in narrative scripts when a scene needs to be restarted.
     /// </summary>
     public void ReloadScene()
     {
-        
+        _sceneLoader.NarrativeScript = _narrativeGameState.NarrativeScriptPlayerComponent.NarrativeScriptPlayer.RootNarrativeScript.Script;
         _sceneLoader.LoadScene(SceneManager.GetActiveScene().name);
     }
 }

--- a/unity-ggjj/Assets/Scripts/BGScenes/SceneController.cs
+++ b/unity-ggjj/Assets/Scripts/BGScenes/SceneController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -36,6 +37,14 @@ public class SceneController : MonoBehaviour, ISceneController
 
     private Coroutine _panToPositionCoroutine;
     private BGScene _activeScene;
+
+    public void Awake()
+    {
+        if (_sceneLoader == null)
+        {
+            throw new NullReferenceException(nameof(_sceneLoader) + " mustn't be set to null");
+        }
+    }
 
     public bool WitnessTestimonyActive
     {
@@ -304,6 +313,7 @@ public class SceneController : MonoBehaviour, ISceneController
     /// </summary>
     public void ReloadScene()
     {
+        
         _sceneLoader.LoadScene(SceneManager.GetActiveScene().name);
     }
 }

--- a/unity-ggjj/Assets/Scripts/GameState/DebugGameStarter.cs
+++ b/unity-ggjj/Assets/Scripts/GameState/DebugGameStarter.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 [RequireComponent(typeof(NarrativeGameState))]
 public class DebugGameStarter : MonoBehaviour
 {
-    [SerializeField] private TextAsset _narrativeScript;
+    public TextAsset narrativeScript;
     
     private NarrativeGameState _narrativeGameState;
     
@@ -14,11 +14,11 @@ public class DebugGameStarter : MonoBehaviour
 
     private void Start()
     {
-        if (_narrativeScript == null) { return; }
-        
-        Debug.Log($"DebugGameStarter: Running script {_narrativeScript.name}");
+        if (narrativeScript == null) { return; }
 
-        _narrativeGameState.NarrativeScriptStorage.NarrativeScript = new NarrativeScript(_narrativeScript);
+        Debug.Log($"DebugGameStarter: Running script {narrativeScript.name}");
+
+        _narrativeGameState.NarrativeScriptStorage.NarrativeScript = new NarrativeScript(narrativeScript);
         _narrativeGameState.StartGame();
     }
 }

--- a/unity-ggjj/Assets/Scripts/NarrativeScript/NarrativeScriptPlayer/INarrativeScriptPlayer.cs
+++ b/unity-ggjj/Assets/Scripts/NarrativeScript/NarrativeScriptPlayer/INarrativeScriptPlayer.cs
@@ -3,6 +3,7 @@ using UnityEngine.InputSystem;
 
 public interface INarrativeScriptPlayer
 {
+    INarrativeScript RootNarrativeScript { get; }
     INarrativeScript ActiveNarrativeScript { get; set; }
     INarrativeScriptPlayer ActiveNarrativeScriptPlayer { get; }
     GameMode GameMode { get; set; }

--- a/unity-ggjj/Assets/Scripts/NarrativeScript/NarrativeScriptPlayer/NarrativeScriptPlayer.cs
+++ b/unity-ggjj/Assets/Scripts/NarrativeScript/NarrativeScriptPlayer/NarrativeScriptPlayer.cs
@@ -50,6 +50,8 @@ public class NarrativeScriptPlayer : INarrativeScriptPlayer
             return IsAtChoice && GameMode == GameMode.CrossExamination && !Waiting;
         }
     }
+
+    public INarrativeScript RootNarrativeScript => _activeNarrativeScript;
     
     public INarrativeScript ActiveNarrativeScript
     {

--- a/unity-ggjj/Assets/Scripts/SceneLoading/SceneLoader.cs
+++ b/unity-ggjj/Assets/Scripts/SceneLoading/SceneLoader.cs
@@ -24,12 +24,25 @@ public class SceneLoader : MonoBehaviour, ISceneLoader
         _transition = GetComponent<ITransition>();
     }
 
+    public void OnDisable()
+    {
+        if (_sceneLoadOperation == null)
+        {
+            return;
+        }
+
+        SceneManager.sceneLoaded -= SetupNextNarrativeScript;
+    }
+
     /// <summary>
     /// Call this method when wanting to change the scene using a specific scene's name.
     /// </summary>
     public void LoadScene(string sceneName)
     {
-        if (Busy) { return; }
+        if (Busy)
+        {
+            return;
+        }
 
         _sceneLoadOperation = SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Additive);
 
@@ -106,7 +119,16 @@ public class SceneLoader : MonoBehaviour, ISceneLoader
         foreach (var rootGameObject in scene.GetRootGameObjects())
         {
             var debugGameStarter = rootGameObject.GetComponent<DebugGameStarter>();
-            if (debugGameStarter == null) continue;
+            if (debugGameStarter == null)
+            {
+                continue;
+            }
+
+            if (debugGameStarter.narrativeScript == null)
+            {
+                continue;
+            }
+            
             Debug.LogWarning($"The scene '{scene.name}' loaded by this {nameof(SceneLoader)} contained a '{nameof(DebugGameStarter)}'. As a {nameof(NarrativeScript)} was specified when loading this scene, this needs to be removed, otherwise '{debugGameStarter.narrativeScript.name}' (the {nameof(NarrativeScript)} specified inside the {nameof(DebugGameStarter)}) will incorrectly take precedence over '{NarrativeScript.name}' (the {nameof(NarrativeScript)} specified inside the {nameof(SceneLoader)})");
             Destroy(debugGameStarter);
         }

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/DebugGameStarterTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/DebugGameStarterTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using Tests.PlayModeTests.Tools;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using Object = UnityEngine.Object;
+
+namespace Tests.PlayModeTests.Scripts
+{
+    public class DebugGameStarterTests
+    {
+        private const string BLANK_SCENE = "Assets/Tests/PlayModeTests/TestScenes/BlankScene.unity";
+        private const string ROSS_COOL_X = "Assets/Tests/PlayModeTests/TestScripts/RossCoolX.json";
+        
+        [UnityTest]
+        public IEnumerator CorrectlySetsUpNarrativePlayer()
+        { 
+            yield return EditorSceneManager.LoadSceneAsyncInPlayMode(BLANK_SCENE, new LoadSceneParameters());
+            var gameStateGameObject = new GameObject();
+            var narrativeGameState = gameStateGameObject.AddComponent<NarrativeGameState>();
+
+            // The NarrativeScriptPlayerComponent fetches the currently active script only the first time "ActiveNarrativeScript" is accessed.
+            // Hence, we need a new instance every time we want to check if the currently "ActiveNarrativeScript" has changed
+            void AssignNewNarrativeScriptPlayerComponent()
+            {
+                var narrativeScriptPlayerComponent = gameStateGameObject.AddComponent<NarrativeScriptPlayerComponent>();
+                var serializedObjectNarrativeScriptPlayerComponent = new SerializedObject(narrativeScriptPlayerComponent);
+                serializedObjectNarrativeScriptPlayerComponent.FindProperty("_narrativeGameState").objectReferenceValue = narrativeGameState;
+                serializedObjectNarrativeScriptPlayerComponent.ApplyModifiedProperties();
+
+                var narrativeGameStateSerializedObject = new SerializedObject(narrativeGameState);
+                narrativeGameStateSerializedObject.FindProperty("_narrativeScriptPlayerComponent").objectReferenceValue = narrativeScriptPlayerComponent;
+                narrativeGameStateSerializedObject.ApplyModifiedProperties();
+            }
+            
+            // Create the `DebugGameStarter` (`Awake()` has been called, however `Start()` hasn't yet)
+            var debugGameStarter = gameStateGameObject.AddComponent<DebugGameStarter>();
+            debugGameStarter.narrativeScript = AssetDatabase.LoadAssetAtPath<TextAsset>(ROSS_COOL_X);
+
+            // We except this to be 'null' and throw an exception at this point, as DebugGameStarter.Start() hasn't run
+            AssignNewNarrativeScriptPlayerComponent();
+            Assert.IsNull(narrativeGameState.NarrativeScriptPlayerComponent.NarrativeScriptPlayer.ActiveNarrativeScript);
+            LogAssert.Expect(LogType.Exception, new Regex($"{nameof(NullReferenceException)}: "));
+            
+            // Complete the Unity Update Loop; this implicitly calls DebugGameStarter.Start()
+            yield return new WaitForSeconds(0.0f);
+
+            // We except this to be properly set now, as DebugGameStarter.Start() has run
+            AssignNewNarrativeScriptPlayerComponent();
+            Assert.AreEqual(narrativeGameState.NarrativeScriptPlayerComponent.NarrativeScriptPlayer.ActiveNarrativeScript!.Script.name, System.IO.Path.GetFileNameWithoutExtension(ROSS_COOL_X));
+        }
+    }
+}

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/DebugGameStarterTests.cs.meta
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/DebugGameStarterTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6d23f0c7d74e41f9901570c715e98c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/SceneLoaderTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/SceneLoaderTests.cs
@@ -1,4 +1,8 @@
+using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using Tests.PlayModeTests.Tools;
 using UnityEditor;
@@ -6,19 +10,137 @@ using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
+using Object = UnityEngine.Object;
 
 namespace Tests.PlayModeTests.Scripts
 {
     public class SceneLoaderTests
     {
+        private const string BLANK_SCENE = "Assets/Tests/PlayModeTests/TestScenes/BlankScene.unity";
+        private const string ROSS_COOL_X = "Assets/Tests/PlayModeTests/TestScripts/RossCoolX.json";
+        private const string GAME_SCENE_NAME = "Game";
+        private const string MAIN_MENU_SCENE_NAME = "MainMenu";
+        
         [UnityTest]
-        public IEnumerator GameSceneCanBeLoadedWithNarrativeScript()
+        public IEnumerator AttemptingToLoadTwoScenesWhileBusyOnlyLoadsScene1()
         {
-            yield return EditorSceneManager.LoadSceneAsyncInPlayMode("Assets/Tests/PlayModeTests/TestScenes/BlankScene.unity", new LoadSceneParameters());
+            const string SCENE1 = GAME_SCENE_NAME;
+            const string SCENE2 = MAIN_MENU_SCENE_NAME;
+            
+            yield return EditorSceneManager.LoadSceneAsyncInPlayMode(BLANK_SCENE, new LoadSceneParameters());
             var sceneLoader = new GameObject().AddComponent<SceneLoader>();
-            sceneLoader.NarrativeScript = AssetDatabase.LoadAssetAtPath<TextAsset>("Assets/Tests/PlayModeTests/TestScripts/RossCoolX.json");
-            sceneLoader.LoadScene("Game");
-            yield return TestTools.WaitForState(() => SceneManager.GetActiveScene().name == "Game");
+            sceneLoader.NarrativeScript = AssetDatabase.LoadAssetAtPath<TextAsset>(ROSS_COOL_X);
+            
+            sceneLoader.LoadScene(SCENE1);
+            sceneLoader.LoadScene(SCENE2);
+            
+            yield return TestTools.WaitForState(() => SceneManager.GetActiveScene().name == SCENE1);
+            var sceneNames = new List<string>(SceneManager.sceneCount);
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                sceneNames.Add(SceneManager.GetSceneAt(i).name);
+            }
+            Assert.True(sceneNames.Any(sceneName => sceneName == SCENE1));
+            Assert.False(sceneNames.Any(sceneName => sceneName == SCENE2));
+        }
+        
+        [UnityTest]
+        public IEnumerator GameSceneCanBeLoadedWithNarrativeScriptWhenNarrativeGameStateIsPresent()
+        {
+            yield return EditorSceneManager.LoadSceneAsyncInPlayMode(BLANK_SCENE, new LoadSceneParameters());
+            var sceneLoader = new GameObject().AddComponent<SceneLoader>();
+            sceneLoader.NarrativeScript = AssetDatabase.LoadAssetAtPath<TextAsset>(ROSS_COOL_X);
+            
+            sceneLoader.LoadScene(GAME_SCENE_NAME);
+            
+            yield return TestTools.WaitForState(() => SceneManager.GetActiveScene().name == GAME_SCENE_NAME);
+            var narrativeGameState = Object.FindObjectOfType<NarrativeGameState>();
+            Assert.AreEqual("RossCoolX", narrativeGameState.NarrativeScriptStorage.NarrativeScript.Script.name);
+        }
+        
+        [UnityTest]
+        public IEnumerator ThrowsExceptionWithoutNarrativeGameStateComponentWhenNeedingToSetNarrativeScript()
+        {
+            yield return EditorSceneManager.LoadSceneAsyncInPlayMode(BLANK_SCENE, new LoadSceneParameters());
+            var sceneLoader = new GameObject().AddComponent<SceneLoader>();
+            sceneLoader.NarrativeScript = AssetDatabase.LoadAssetAtPath<TextAsset>(ROSS_COOL_X);
+
+            sceneLoader.LoadScene(MAIN_MENU_SCENE_NAME);
+            
+            yield return TestTools.WaitForState(() =>
+            {
+                for (var i = 0; i < SceneManager.sceneCount; i++)
+                {
+                    var scene = SceneManager.GetSceneAt(i);
+                    if (scene.name != MAIN_MENU_SCENE_NAME)
+                    {
+                        continue;
+                    }
+
+                    if (!scene.isLoaded)
+                    {
+                        continue;
+                    }
+
+                    return true;
+                }
+
+                return false;
+            });
+            LogAssert.Expect(LogType.Exception, new Regex($"{nameof(NullReferenceException)}: "));
+        }
+        
+        [UnityTest]
+        public IEnumerator SucceedsWithoutNarrativeGameStateIfNoNarrativeScriptIsSet()
+        {
+            yield return EditorSceneManager.LoadSceneAsyncInPlayMode(BLANK_SCENE, new LoadSceneParameters());
+            var sceneLoader = new GameObject().AddComponent<SceneLoader>();
+            sceneLoader.NarrativeScript = null;
+            
+            sceneLoader.LoadScene(MAIN_MENU_SCENE_NAME);
+            
+            yield return TestTools.WaitForState(() => SceneManager.GetActiveScene().name == MAIN_MENU_SCENE_NAME);
+        }
+
+        [UnityTest]
+        public IEnumerator DebugGameStarterGetsSkipped()
+        {
+            yield return EditorSceneManager.LoadSceneAsyncInPlayMode(BLANK_SCENE, new LoadSceneParameters());
+            var sceneLoader = new GameObject().AddComponent<SceneLoader>();
+            sceneLoader.NarrativeScript = AssetDatabase.LoadAssetAtPath<TextAsset>(ROSS_COOL_X);
+
+            var debugGameStarterWasSetUp = false;
+
+            void OnSceneManagerOnsceneLoaded(Scene scene, LoadSceneMode mode)
+            {
+                SceneManager.sceneLoaded -= OnSceneManagerOnsceneLoaded;
+                if (scene.name != GAME_SCENE_NAME)
+                {
+                    return;
+                }
+
+                DebugGameStarter debugGameStarter = null;
+                foreach (var rootGameObject in scene.GetRootGameObjects())
+                {
+                    debugGameStarter = rootGameObject.GetComponent<DebugGameStarter>();
+                    if (debugGameStarter != null)
+                    {
+                        break;
+                    }
+                }
+
+                Assert.IsNotNull(debugGameStarter, "The Game scene requires a DebugGameStarter; if this should not be used, unset the narrative script inside it instead");
+                debugGameStarter.GetComponent<DebugGameStarter>().narrativeScript = AssetDatabase.LoadAssetAtPath<TextAsset>("Assets/Tests/PlayModeTests/TestScripts/DynamicAudio.json");
+
+                debugGameStarterWasSetUp = true;
+            }
+
+            SceneManager.sceneLoaded += OnSceneManagerOnsceneLoaded;
+                
+            sceneLoader.LoadScene(GAME_SCENE_NAME);
+            
+            yield return TestTools.WaitForState(() => SceneManager.GetActiveScene().name == GAME_SCENE_NAME);
+            Assert.IsTrue(debugGameStarterWasSetUp);
             var narrativeGameState = Object.FindObjectOfType<NarrativeGameState>();
             Assert.AreEqual("RossCoolX", narrativeGameState.NarrativeScriptStorage.NarrativeScript.Script.name);
         }

--- a/unity-ggjj/ProjectSettings/PackageManagerSettings.asset
+++ b/unity-ggjj/ProjectSettings/PackageManagerSettings.asset
@@ -12,10 +12,12 @@ MonoBehaviour:
   m_Script: {fileID: 13964, guid: 0000000000000000e000000000000000, type: 0}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_EnablePreviewPackages: 0
+  m_EnablePreReleasePackages: 0
   m_EnablePackageDependencies: 0
   m_AdvancedSettingsExpanded: 1
   m_ScopedRegistriesSettingsExpanded: 1
+  m_SeeAllPackageVersions: 0
+  m_DismissPreviewPackagesInUse: 0
   oneTimeWarningShown: 0
   m_Registries:
   - m_Id: main
@@ -24,28 +26,20 @@ MonoBehaviour:
     m_Scopes: []
     m_IsDefault: 1
     m_Capabilities: 7
-  - m_Id: scoped:OpenUPM
+    m_ConfigSource: 0
+  - m_Id: scoped:project:OpenUPM
     m_Name: OpenUPM
     m_Url: https://package.openupm.com
     m_Scopes:
     - com.inklestudios.ink-unity-integration
     m_IsDefault: 0
     m_Capabilities: 0
-  m_UserSelectedRegistryName: 
+    m_ConfigSource: 4
+  m_UserSelectedRegistryName: OpenUPM
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
-    m_ErrorMessage: 
-    m_Original:
-      m_Id: scoped:OpenUPM
-      m_Name: OpenUPM
-      m_Url: https://package.openupm.com
-      m_Scopes:
-      - com.inklestudios.ink-unity-integration
-      m_IsDefault: 0
-      m_Capabilities: 0
     m_Modified: 0
-    m_Name: OpenUPM
-    m_Url: https://package.openupm.com
-    m_Scopes:
-    - com.inklestudios.ink-unity-integration
-    m_SelectedScopeIndex: 0
+    m_ErrorMessage: 
+    m_UserModificationsInstanceId: -828
+    m_OriginalInstanceId: -832
+  m_LoadAssets: 0

--- a/unity-ggjj/ProjectSettings/ProjectVersion.txt
+++ b/unity-ggjj/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
 m_EditorVersion: 2022.1.23f1
-m_EditorVersionWithRevision: 2022.1.23f1 (7321c9670bc2)
+m_EditorVersionWithRevision: 2022.1.23f1 (9636b062134a)


### PR DESCRIPTION
## Summary
This PR resolves the issue described inside #316.
It also resolves an issue with the test pipelines where Code Coverage wasn't properly posted to codecov.io in all commits after 51f13304a7052e1443c79b8b861038df1524b621 (which updated the CI test runner).

## Before/after screenshots and/or animated gif
Before this change, a call to `RELOAD_SCENE` loaded a new instance of the `Game` scene and unloaded the currently active instance afterward.  
This resulted in two possible outcomes both of which were unexpected.  
When encountering `RELOAD_SCENE`...
- **after starting the `Game` scene using the `DebugGameStarter` to jump to a specific scene**, the newly loaded `Game` scene would still contain that `DebugGameStarter` and restart the game from that script 
   (for example: start the game with the `DebugGameStarter` set to `1-5`, fail the cross-examination in `1-6` enough times until your game is over, and notice how the game will return to `1-5` instead)
- **after starting the `Game` scene using the `MainMenu`**, the game will actually freeze; the `Game` scene is reloaded, but the `SceneLoader` starting the game at `1-1` is actually part of the `MainMenu` and therefore missing

## Testing instructions
**Case 1:**
1. Start the game from the `New Game` button (you can change the button to start the game at `1-5`, 
to skip most linear content)
2. Fail the cross-examination inside `1-6`
3. Notice the game starts from the cross-examination, rather than freezing with "Lorem impsum..." placeholder text

**Case 2:**
1. Start the game from the `Game` scene; set the `DebugGameStarter` to `1-5`, to skip most linear content
2. Fail the cross-examination inside `1-6`
3. Notice the game starts from the cross-examination, rather than the witness testimony

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[x]` Has associated resource: 
  - closes #316 
  <!--- Include any project card, github issue, etc. associated with this PR -->
