### PR TITLE
Speed up text if "X" is held right after continuing the story

### DIFF
--- a/unity-ggjj/Assets/Scenes/Game.unity
+++ b/unity-ggjj/Assets/Scenes/Game.unity
@@ -770,6 +770,22 @@ MonoBehaviour:
             m_StringArgument: 
             m_BoolArgument: 0
           m_CallState: 2
+  - _inputActionReference: {fileID: -5681408003504861312, guid: 3b3ca44a1d04d4c5c847c1b48fb83536, type: 3}
+    _event:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 8054490722184616645}
+          m_TargetAssemblyTypeName: NarrativeScriptPlayerComponent, GG-JointJustice
+          m_MethodName: ToggleSpeedup
+          m_Mode: 0
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!4 &342284812
 Transform:
   m_ObjectHideFlags: 0

--- a/unity-ggjj/Assets/Scripts/Input/Controls.inputactions
+++ b/unity-ggjj/Assets/Scripts/Input/Controls.inputactions
@@ -6,6 +6,14 @@
             "id": "de1537fe-4eb2-4289-b2fb-a49589bc443e",
             "actions": [
                 {
+                    "name": "ToggleTextSpeedupHeld",
+                    "type": "Button",
+                    "id": "d11b3523-5e0b-4724-a4f8-073913306fe1",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
                     "name": "ToggleTextSpeedup",
                     "type": "Button",
                     "id": "73cf0c6d-7a5f-4586-b850-5726b955b4f5",
@@ -233,6 +241,17 @@
                     "processors": "",
                     "groups": "Touch",
                     "action": "Cursor",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e33c568f-033e-4c5b-b314-c8aec15ab0d6",
+                    "path": "<Keyboard>/x",
+                    "interactions": "Hold",
+                    "processors": "",
+                    "groups": "Mouse and Keyboard",
+                    "action": "ToggleTextSpeedupHeld",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }


### PR DESCRIPTION
## Summary
Implements #314

## Before/after screenshots and/or animated gif
**Before:**

https://user-images.githubusercontent.com/1689033/211172019-3ef0ee27-1e59-4af6-975f-efaa83e3a7c1.mp4

**After:**

https://user-images.githubusercontent.com/1689033/211171906-5e4a52b3-8ba1-41a4-888a-04312e889e0b.mp4

## Testing instructions
1. Start the game
2. Wait for a line of text to appear, that is followed by another line of text
3. Press **and hold** X
4. Notice how the next text is shown and starts to speed up after 0.5 seconds
   (Previously the text would've continued at normal speed; to speed it up, the player would have to release and re-press X.) 

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[x]` Has associated resource: #314 
  <!--- Include any project card, github issue, etc. associated with this PR -->
