### PR TITLE
Added test tool to do UI snapshot testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,7 @@ jobs:
         if: ${{ failure() || success() }}
         with:
           name: Screenshots - PlayMode Scripts
-          path: TestRunArtifacts
+          path: unity-ggjj/TestRunArtifacts
 
   unityTestPlayModeScenes:
     name: Run PlayMode Scenes tests for Unity project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
         run: rm -rf unity-ggjj/Assets/Tests/PlayModeTests/
 
       - name: Run tests
-        uses: game-ci/unity-test-runner@v2.1.1
+        uses: vimaster/unity-test-runner@v2.1.1
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
@@ -155,7 +155,7 @@ jobs:
           rm -rf unity-ggjj/Assets/Tests/PlayModeTests/Playthrough
 
       - name: Run tests
-        uses: game-ci/unity-test-runner@v2.1.1
+        uses: vimaster/unity-test-runner@v2.1.1
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
@@ -219,7 +219,7 @@ jobs:
           rm -rf unity-ggjj/Assets/Tests/PlayModeTests/Playthrough
 
       - name: Run tests
-        uses: game-ci/unity-test-runner@v2.1.1
+        uses: vimaster/unity-test-runner@v2.1.1
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
@@ -283,7 +283,7 @@ jobs:
           rm -rf unity-ggjj/Assets/Tests/PlayModeTests/Scenes
 
       - name: Run tests
-        uses: game-ci/unity-test-runner@v2.1.1
+        uses: vimaster/unity-test-runner@v2.1.1
         env:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,13 @@ jobs:
           name: Test Results - PlayMode Scripts
           path: artifacts
 
+      - name: Store Screenshots
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() || success() }}
+        with:
+          name: Screenshots - PlayMode Scripts
+          path: TestRunArtifacts
+
   unityTestPlayModeScenes:
     name: Run PlayMode Scenes tests for Unity project
     needs: [checkLicense]
@@ -240,6 +247,13 @@ jobs:
           name: Test Results - PlayMode Scenes
           path: artifacts
 
+      - name: Store Screenshots
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() || success() }}
+        with:
+          name: Screenshots - PlayMode Scenes
+          path: TestRunArtifacts
+
   unityTestPlayModePlaythrough:
     name: Run PlayMode Playthrough tests for Unity project
     needs: [checkLicense]
@@ -296,6 +310,13 @@ jobs:
         with:
           name: Test Results - PlayMode Playthrough
           path: artifacts
+
+      - name: Store Screenshots
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() || success() }}
+        with:
+          name: Screenshots - PlayMode Playthrough
+          path: TestRunArtifacts
 
   unityBuild:
     name: Build for ${{ matrix.targetPlatform.outputName }}

--- a/unity-ggjj/.gitignore
+++ b/unity-ggjj/.gitignore
@@ -73,3 +73,6 @@ Assets/InitTestScene*
 Assets/ERP
 Assets/ERP.meta
 .erp
+
+# Snapshot testing artifacts
+TestRunArtifacts/

--- a/unity-ggjj/Assets/Editor/Scripts/Resolution.cs
+++ b/unity-ggjj/Assets/Editor/Scripts/Resolution.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace Editor.Scripts
+{
+    public static class GameViewUtils
+    {
+        private static readonly object GameViewSizesInstance;
+        private static readonly MethodInfo GetGroupInfo;
+
+        static GameViewUtils()
+        {
+            var sizesType = typeof(UnityEditor.Editor).Assembly.GetType("UnityEditor.GameViewSizes");
+            var singleType = typeof(ScriptableSingleton<>).MakeGenericType(sizesType);
+            var instanceProp = singleType.GetProperty("instance");
+            GetGroupInfo = sizesType.GetMethod("GetGroup");
+            GameViewSizesInstance = instanceProp.GetValue(null, null);
+        }
+
+        [UnityEditor.MenuItem("Test/SetTestSize")]
+        public static void SetTestSize()
+        {
+            int idx = FindSize(GameViewSizeGroupType.Standalone, 1280, 720);
+            if (idx != -1)
+                SetSize(idx);
+        }
+
+        private static void SetSize(int index)
+        {
+            var gvWndType = typeof(UnityEditor.Editor).Assembly.GetType("UnityEditor.GameView");
+            var selectedSizeIndexProp = gvWndType.GetProperty("selectedSizeIndex",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            var gvWnd = EditorWindow.GetWindow(gvWndType);
+            selectedSizeIndexProp.SetValue(gvWnd, index, null);
+        }
+
+        [UnityEditor.MenuItem("Test/SizeDimensionsQuery")]
+        public static void SizeDimensionsQueryTest()
+        {
+            Debug.Log(SizeExists(GameViewSizeGroupType.Standalone, 123, 456));
+        }
+
+        public static int FindSize(GameViewSizeGroupType sizeGroupType, string text)
+        {
+            var group = GetGroup(sizeGroupType);
+            var getDisplayTexts = group.GetType().GetMethod("GetDisplayTexts");
+            var displayTexts = getDisplayTexts.Invoke(group, null) as string[];
+            for (int i = 0; i < displayTexts.Length; i++)
+            {
+                string display = displayTexts[i];
+                int pren = display.IndexOf('(');
+                if (pren != -1)
+                    display = display.Substring(0, pren - 1);
+                if (display == text)
+                    return i;
+            }
+
+            return -1;
+        }
+
+        private static bool SizeExists(GameViewSizeGroupType sizeGroupType, int width, int height)
+        {
+            return FindSize(sizeGroupType, width, height) != -1;
+        }
+
+        private static int FindSize(GameViewSizeGroupType sizeGroupType, int width, int height)
+        {
+            var group = GetGroup(sizeGroupType);
+            var groupType = group.GetType();
+            var getBuiltinCount = groupType.GetMethod("GetBuiltinCount");
+            var getCustomCount = groupType.GetMethod("GetCustomCount");
+            int sizesCount = (int)getBuiltinCount.Invoke(group, null) + (int)getCustomCount.Invoke(group, null);
+            var getGameViewSize = groupType.GetMethod("GetGameViewSize");
+            var gvsType = getGameViewSize.ReturnType;
+            var widthProp = gvsType.GetProperty("width");
+            var heightProp = gvsType.GetProperty("height");
+            var indexValue = new object[1];
+            for (int i = 0; i < sizesCount; i++)
+            {
+                indexValue[0] = i;
+                var size = getGameViewSize.Invoke(group, indexValue);
+                int sizeWidth = (int)widthProp.GetValue(size, null);
+                int sizeHeight = (int)heightProp.GetValue(size, null);
+                if (sizeWidth == width && sizeHeight == height)
+                    return i;
+            }
+
+            return -1;
+        }
+
+        private static object GetGroup(GameViewSizeGroupType type)
+        {
+            return GetGroupInfo.Invoke(GameViewSizesInstance, new object[] { (int)type });
+        }
+
+        private static GameViewSizeGroupType GetCurrentGroupType()
+        {
+            var getCurrentGroupTypeProp = GameViewSizesInstance.GetType().GetProperty("currentGroupType");
+            return (GameViewSizeGroupType)(int)getCurrentGroupTypeProp.GetValue(GameViewSizesInstance, null);
+        }
+    
+        [UnityEditor.MenuItem("Test/LogCurrentGroupType")]
+        private static void LogCurrentGroupType()
+        {
+            Debug.Log(GetCurrentGroupType());
+        }
+    }
+
+    public class Resolution : MonoBehaviour
+    {
+        [RuntimeInitializeOnLoadMethod]
+        private static void OnRuntimeMethodLoad()
+        {
+            GameViewUtils.SetTestSize();
+        }
+    }
+}

--- a/unity-ggjj/Assets/Editor/Scripts/Resolution.cs.meta
+++ b/unity-ggjj/Assets/Editor/Scripts/Resolution.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c2ea150ebb13d30409e37b04ca3534d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/PauseMenu/PauseMenuTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/PauseMenu/PauseMenuTests.cs
@@ -29,8 +29,10 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
         protected readonly InputTestTools inputTestTools = new InputTestTools();
 
         [SetUp]
-        public void Setup()
+        public IEnumerator Setup()
         {
+            Screen.SetResolution(1280, 720, false);
+            yield return new WaitForEndOfFrame();
             inputTestTools.Setup();
         }
 

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/PauseMenu/PauseMenuTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/PauseMenu/PauseMenuTests.cs
@@ -137,6 +137,7 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
         {
             yield return inputTestTools.PressForFrame(Keyboard.escapeKey);
             Assert.IsTrue(PauseMenu.isActiveAndEnabled);
+            yield return ScreenshotDiff.TakeScreenshotOrCompare();
             yield return selectionMethod();
             yield return TestTools.WaitForState(() => SceneManager.GetActiveScene().name == "MainMenu");
         }

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/PauseMenu/PauseMenuTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/PauseMenu/PauseMenuTests.cs
@@ -28,7 +28,7 @@ namespace Tests.PlayModeTests.Scripts.PauseMenu
 
         protected readonly InputTestTools inputTestTools = new InputTestTools();
 
-        [SetUp]
+        [UnitySetUp]
         public IEnumerator Setup()
         {
             Screen.SetResolution(1280, 720, false);

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Tools/ScreenshotDiff.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Tools/ScreenshotDiff.cs
@@ -76,9 +76,9 @@ public class ScreenshotDiff
 
     private static void ExportToArtifactDirectory(string actualFilePath, string expectedFilePath)
     {
-        var fileNameOfFilePath = $"{Path.GetFileName(Path.GetDirectoryName(actualFilePath))}.{Path.GetFileNameWithoutExtension(actualFilePath)}";
+        var fileNameOfFilePath = Path.GetFileNameWithoutExtension(expectedFilePath);
         var runDirectory = TestContext.CurrentTestExecutionContext.StartTime.ToString("s").Replace(":", "-");
-        var targetDirectory = Path.GetFullPath(Path.Join(Application.dataPath, $"../TestRunArtifacts/{runDirectory}/"));
+        var targetDirectory = Path.GetFullPath(Path.Join(Application.dataPath, $"../TestRunArtifacts/{runDirectory}/{Path.GetFileName(Path.GetDirectoryName(expectedFilePath))}"));
         if (!Directory.Exists(targetDirectory))
         {
             Directory.CreateDirectory(targetDirectory);

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Tools/ScreenshotDiff.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Tools/ScreenshotDiff.cs
@@ -1,0 +1,91 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+
+public class ScreenshotDiff
+{
+    private static readonly Dictionary<string, int> CurrentCount = new Dictionary<string, int>();
+
+    static IEnumerator captureScreenshot(string path)
+    {
+        yield return new WaitForEndOfFrame();
+
+        Texture2D screenImage = new Texture2D(Screen.width, Screen.height);
+        screenImage.ReadPixels(new Rect(0, 0, Screen.width, Screen.height), 0, 0);
+        screenImage.Apply();
+        var imageBytes = screenImage.EncodeToPNG();
+
+        File.WriteAllBytes(path, imageBytes);
+    }
+    
+    public static IEnumerator TakeScreenshotOrCompare()
+    {
+        var currentTestName = TestContext.CurrentContext.Test.FullName;
+        var currentCount = CurrentCount.ContainsKey(currentTestName) ? CurrentCount[currentTestName] + 1 : 1;
+        CurrentCount[currentTestName] = currentCount;
+
+        var expectedFilePath = Path.Join( Application.dataPath, $"Tests/PlayModeTests/Tools/Screenshots/{currentTestName}/{currentCount}.png");
+        expectedFilePath = Path.GetFullPath(expectedFilePath);
+        
+        Directory.CreateDirectory(Path.GetDirectoryName(expectedFilePath)!);
+        
+        if (File.Exists(expectedFilePath))
+        {
+            var actualFilePath = Path.GetTempFileName();
+            yield return captureScreenshot(actualFilePath);
+            Assert.IsTrue(PNGIsIdentical(actualFilePath, expectedFilePath), "Expected screenshot {0} is different from actual {1}", expectedFilePath, actualFilePath);
+            yield break;
+        }
+        
+        if (System.Environment.GetCommandLineArgs().Contains("-batchmode"))
+        {
+            Assert.Fail($"Screenshot {expectedFilePath} doesn't exist; have you committed the file after it got created locally?");
+        }
+        
+        yield return captureScreenshot(expectedFilePath);
+        Debug.LogWarning($"Screenshot {expectedFilePath} created; make sure to commit it");
+    }
+
+    private static bool PNGIsIdentical(string actualFilePath, string expectedFilePath)
+    {
+        var file = File.ReadAllBytes(actualFilePath);
+        var temp = File.ReadAllBytes(expectedFilePath);
+        if (file.Length != temp.Length)
+        {
+            Debug.LogWarning($"File {actualFilePath} ({file.Length}) and {expectedFilePath}({temp.Length}) are not the same length");
+            ExportToArtifactDirectory(actualFilePath, expectedFilePath);
+            return false;
+        }
+        for (var i = 0; i < file.Length; i++)
+        {
+            if (file[i] == temp[i])
+            {
+                continue;
+            }
+
+            Debug.LogWarning($"File {actualFilePath} and {expectedFilePath} are not the same at index {i}");
+            ExportToArtifactDirectory(actualFilePath, expectedFilePath);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void ExportToArtifactDirectory(string actualFilePath, string expectedFilePath)
+    {
+        var fileNameOfFilePath = $"{Path.GetFileName(Path.GetDirectoryName(actualFilePath))}.{Path.GetFileNameWithoutExtension(actualFilePath)}";
+        var runDirectory = TestContext.CurrentTestExecutionContext.StartTime.ToString("s");
+        var runDirectoryWithOnlyValidCharacters = string.Join("-", runDirectory.Split(Path.GetInvalidFileNameChars()));
+        var targetDirectory = Path.GetFullPath(Path.Join(Application.dataPath, $"../TestRunArtifacts/{runDirectoryWithOnlyValidCharacters}/"));
+        if (!Directory.Exists(targetDirectory))
+        {
+            Directory.CreateDirectory(targetDirectory);
+        }
+        
+        File.Copy(actualFilePath, Path.GetFullPath(Path.Join(targetDirectory, $"{fileNameOfFilePath}.actual.png")));
+        File.Copy(expectedFilePath, Path.GetFullPath(Path.Join(targetDirectory, $"{fileNameOfFilePath}.expected.png")));
+    }
+}

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Tools/ScreenshotDiff.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Tools/ScreenshotDiff.cs
@@ -77,9 +77,8 @@ public class ScreenshotDiff
     private static void ExportToArtifactDirectory(string actualFilePath, string expectedFilePath)
     {
         var fileNameOfFilePath = $"{Path.GetFileName(Path.GetDirectoryName(actualFilePath))}.{Path.GetFileNameWithoutExtension(actualFilePath)}";
-        var runDirectory = TestContext.CurrentTestExecutionContext.StartTime.ToString("s");
-        var runDirectoryWithOnlyValidCharacters = string.Join("-", runDirectory.Split(Path.GetInvalidFileNameChars()));
-        var targetDirectory = Path.GetFullPath(Path.Join(Application.dataPath, $"../TestRunArtifacts/{runDirectoryWithOnlyValidCharacters}/"));
+        var runDirectory = TestContext.CurrentTestExecutionContext.StartTime.ToString("s").Replace(":", "-");
+        var targetDirectory = Path.GetFullPath(Path.Join(Application.dataPath, $"../TestRunArtifacts/{runDirectory}/"));
         if (!Directory.Exists(targetDirectory))
         {
             Directory.CreateDirectory(targetDirectory);

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Tools/ScreenshotDiff.cs.meta
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Tools/ScreenshotDiff.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 253483f3cbe58c44da0575446b8295f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Tools/Screenshots.meta
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Tools/Screenshots.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 757d40b5ad6b7424f9458418b2a8cb1d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Tools/Screenshots/Tests.PlayModeTests.Scripts.PauseMenu.ViaKeyboard.MainMenuButtonReturnsToMainMenu.meta
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Tools/Screenshots/Tests.PlayModeTests.Scripts.PauseMenu.ViaKeyboard.MainMenuButtonReturnsToMainMenu.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d603bc9d6d5c24d4b9a6c7fdb8156b40
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Tools/Screenshots/Tests.PlayModeTests.Scripts.PauseMenu.ViaKeyboard.MainMenuButtonReturnsToMainMenu/1.png
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Tools/Screenshots/Tests.PlayModeTests.Scripts.PauseMenu.ViaKeyboard.MainMenuButtonReturnsToMainMenu/1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9f01eccfe46bf6787bacda281d85bfe631bbba2dc00b89623675d9e3bedbb4d
+size 26683

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Tools/Screenshots/Tests.PlayModeTests.Scripts.PauseMenu.ViaKeyboard.MainMenuButtonReturnsToMainMenu/1.png.meta
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Tools/Screenshots/Tests.PlayModeTests.Scripts.PauseMenu.ViaKeyboard.MainMenuButtonReturnsToMainMenu/1.png.meta
@@ -1,0 +1,124 @@
+fileFormatVersion: 2
+guid: e1777396105ea524a8499f3f797088c2
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/unity-ggjj.sln.DotSettings
+++ b/unity-ggjj/unity-ggjj.sln.DotSettings
@@ -1,6 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=BG/@EntryIndexedValue">BG</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Arin/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=batchmode/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Coroutine/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dinos/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Fader/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
# DRAFT PR UNTIL BUILD WORKFLOW IS UPDATED TO UPLOAD SCREENSHOTS OF FAILED TESTS

## Summary
To prevent issues like #312 from reoccurring I added a one-line tool that can be added to do [snapshot testing similar to Jest](https://jestjs.io/docs/snapshot-testing).

When initially hit, Unity creates a screenshot, which needs to be committed to the repository. For all subsequent runs, Unity creates another screenshot and compares it with the one stored inside the repository.

## Before/after screenshots and/or animated gif
Adding `yield return ScreenshotDiff.TakeScreenshotOrCompare()` to any test causes one these things to happen:
- **if there's no "expected state" yet and the Editor is open...**
  1. Unity takes a screenshot and stores it inside `/Assets/Tests/PlayModeTests/Tools/Screenshots/{FullNameOfTest}/{TakeScreenshotOrCompareWasCalledInsideTest}.png`
  3. Unity continues the test
  4. this file becomes the "expected state" of the UI at that point; commit this file to the repository
- **if there's no "expected state" yet and  the test is running on GitHub...**
  1. Unity marks the test as failed as there's no "expected" state for Unity to compare against
     <img width="1314" alt="image" src="https://user-images.githubusercontent.com/1689033/219944272-d10abbcb-e489-4251-952e-66fb11653a3a.png">
- **if the "expected state" exists...**
  1. Unity takes a screenshot as "actual state" and stores it inside a temporary location
  2. Compares the "actual" with the "expected" state
      1. if it matches
          1. the test continues
      2. if it doesn't match
          1. Unity copies the expected and actual screenshot to `/TestRunArtifacts/TestContext.CurrentTestExecutionContext.StartTime/{FullNameOfTest}.{TakeScreenshotOrCompareWasCalledInsideTest}`
          2. Unity marks the test as failed and uploads both expected and actual screenshots
             <img width="1316" alt="image" src="https://user-images.githubusercontent.com/1689033/219944088-956239b9-4d0c-4263-9425-b89a80fc9ead.png">
             <img width="857" alt="image" src="https://user-images.githubusercontent.com/1689033/219944211-d3f7d929-0d14-4b55-b3d2-b3f10332c74e.png">


## Testing instructions
not yet available 

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[ ]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->
