### PR TITLE
Edit NarrativeScripts inside Development Builds of the game

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -390,6 +390,7 @@ jobs:
           projectPath: unity-ggjj/
           targetPlatform: ${{ matrix.targetPlatform.unityPlatform }}
           buildName: 'Game Grumps - Joint Justice'
+          customParameters: "${{ (github.event.inputs.createRelease != 'true') && '-Development -AllowDebugging' }}"
 
       - name: Upload '${{ matrix.targetPlatform.outputName }}' artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -390,8 +390,8 @@ jobs:
           projectPath: unity-ggjj/
           targetPlatform: ${{ matrix.targetPlatform.unityPlatform }}
           buildName: 'Game Grumps - Joint Justice'
-          customParameters: "${{ (github.event.inputs.createRelease != 'true') && '-Development -AllowDebugging' }}"
-
+          customParameters: "${{ (github.event.inputs.createRelease != 'true') && (matrix.targetPlatform.unityPlatform != 'WebGL') && '-Development -AllowDebugging' }}" # https://forum.unity.com/threads/unable-to-make-webgl-development-builds.1274915/#post-8097197
+ 
       - name: Upload '${{ matrix.targetPlatform.outputName }}' artifact
         uses: actions/upload-artifact@v3
         with:

--- a/unity-ggjj/.gitignore
+++ b/unity-ggjj/.gitignore
@@ -4,6 +4,7 @@
 [Bb]uild/
 [Bb]uilds/
 [Ll]ogs/
+[Dd]ev[Kk]it/
 [Cc]ode[Cc]overage/
 /[Uu]ser[Ss]ettings/
 

--- a/unity-ggjj/Assets/Scenes/Game.unity
+++ b/unity-ggjj/Assets/Scenes/Game.unity
@@ -5234,7 +5234,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 456175c2b594046d3923a6d20445dd86, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  narrativeScript: {fileID: 4900000, guid: c2d26570bbb424d3598fa05e0d7adbaf, type: 3}
+  narrativeScript: {fileID: 0}
 --- !u!1 &8699442053336843567
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity-ggjj/Assets/Scenes/Game.unity
+++ b/unity-ggjj/Assets/Scenes/Game.unity
@@ -3149,6 +3149,51 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _narrativeGameState: {fileID: 7963640705624872190}
+--- !u!1 &1075336302
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1075336304}
+  - component: {fileID: 1075336303}
+  m_Layer: 0
+  m_Name: RuntimeEditor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1075336303
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1075336302}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 665a068ae74cc6944822fe633c5fab62, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  narrativeGameState: {fileID: 7963640705624872190}
+--- !u!4 &1075336304
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1075336302}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.03352965, y: -0.32519466, z: 69.20322}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 17
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1082074317
 GameObject:
   m_ObjectHideFlags: 0
@@ -5189,7 +5234,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 456175c2b594046d3923a6d20445dd86, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  narrativeScript: {fileID: 0}
+  narrativeScript: {fileID: 4900000, guid: c2d26570bbb424d3598fa05e0d7adbaf, type: 3}
 --- !u!1 &8699442053336843567
 GameObject:
   m_ObjectHideFlags: 0

--- a/unity-ggjj/Assets/Scripts/Input/DebugControls.cs
+++ b/unity-ggjj/Assets/Scripts/Input/DebugControls.cs
@@ -1,0 +1,183 @@
+// GENERATED AUTOMATICALLY FROM 'Assets/Scripts/Input/DebugControls.inputactions'
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Utilities;
+
+public class @DebugControls : IInputActionCollection, IDisposable
+{
+    public InputActionAsset asset { get; }
+    public @DebugControls()
+    {
+        asset = InputActionAsset.FromJson(@"{
+    ""name"": ""DebugControls"",
+    ""maps"": [
+        {
+            ""name"": ""Keyboard/Mouse"",
+            ""id"": ""40c3f060-180e-43d6-981b-b4ece39e00eb"",
+            ""actions"": [
+                {
+                    ""name"": ""ReloadScript"",
+                    ""type"": ""Button"",
+                    ""id"": ""948de251-4bce-431b-b749-fa13b7c4499b"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """"
+                },
+                {
+                    ""name"": ""OpenEditor"",
+                    ""type"": ""Button"",
+                    ""id"": ""dce34266-8a6c-4591-a6e9-d2e1fa6dca54"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": """"
+                }
+            ],
+            ""bindings"": [
+                {
+                    ""name"": """",
+                    ""id"": ""d75864a1-7b83-4223-bbda-c15887431023"",
+                    ""path"": ""<Keyboard>/r"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""ReloadScript"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""Button With One Modifier"",
+                    ""id"": ""6989c641-2aa1-4c80-9640-99fc81755009"",
+                    ""path"": ""ButtonWithOneModifier"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""OpenEditor"",
+                    ""isComposite"": true,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""modifier"",
+                    ""id"": ""cd357d8f-24b0-477a-80bd-7bf1653f4940"",
+                    ""path"": ""<Keyboard>/ctrl"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""OpenEditor"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""button"",
+                    ""id"": ""1560bb35-bd93-4f6d-93f6-283feb1179f8"",
+                    ""path"": ""<Keyboard>/r"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""OpenEditor"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                }
+            ]
+        }
+    ],
+    ""controlSchemes"": []
+}");
+        // Keyboard/Mouse
+        m_KeyboardMouse = asset.FindActionMap("Keyboard/Mouse", throwIfNotFound: true);
+        m_KeyboardMouse_ReloadScript = m_KeyboardMouse.FindAction("ReloadScript", throwIfNotFound: true);
+        m_KeyboardMouse_OpenEditor = m_KeyboardMouse.FindAction("OpenEditor", throwIfNotFound: true);
+    }
+
+    public void Dispose()
+    {
+        UnityEngine.Object.Destroy(asset);
+    }
+
+    public InputBinding? bindingMask
+    {
+        get => asset.bindingMask;
+        set => asset.bindingMask = value;
+    }
+
+    public ReadOnlyArray<InputDevice>? devices
+    {
+        get => asset.devices;
+        set => asset.devices = value;
+    }
+
+    public ReadOnlyArray<InputControlScheme> controlSchemes => asset.controlSchemes;
+
+    public bool Contains(InputAction action)
+    {
+        return asset.Contains(action);
+    }
+
+    public IEnumerator<InputAction> GetEnumerator()
+    {
+        return asset.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    public void Enable()
+    {
+        asset.Enable();
+    }
+
+    public void Disable()
+    {
+        asset.Disable();
+    }
+
+    // Keyboard/Mouse
+    private readonly InputActionMap m_KeyboardMouse;
+    private IKeyboardMouseActions m_KeyboardMouseActionsCallbackInterface;
+    private readonly InputAction m_KeyboardMouse_ReloadScript;
+    private readonly InputAction m_KeyboardMouse_OpenEditor;
+    public struct KeyboardMouseActions
+    {
+        private @DebugControls m_Wrapper;
+        public KeyboardMouseActions(@DebugControls wrapper) { m_Wrapper = wrapper; }
+        public InputAction @ReloadScript => m_Wrapper.m_KeyboardMouse_ReloadScript;
+        public InputAction @OpenEditor => m_Wrapper.m_KeyboardMouse_OpenEditor;
+        public InputActionMap Get() { return m_Wrapper.m_KeyboardMouse; }
+        public void Enable() { Get().Enable(); }
+        public void Disable() { Get().Disable(); }
+        public bool enabled => Get().enabled;
+        public static implicit operator InputActionMap(KeyboardMouseActions set) { return set.Get(); }
+        public void SetCallbacks(IKeyboardMouseActions instance)
+        {
+            if (m_Wrapper.m_KeyboardMouseActionsCallbackInterface != null)
+            {
+                @ReloadScript.started -= m_Wrapper.m_KeyboardMouseActionsCallbackInterface.OnReloadScript;
+                @ReloadScript.performed -= m_Wrapper.m_KeyboardMouseActionsCallbackInterface.OnReloadScript;
+                @ReloadScript.canceled -= m_Wrapper.m_KeyboardMouseActionsCallbackInterface.OnReloadScript;
+                @OpenEditor.started -= m_Wrapper.m_KeyboardMouseActionsCallbackInterface.OnOpenEditor;
+                @OpenEditor.performed -= m_Wrapper.m_KeyboardMouseActionsCallbackInterface.OnOpenEditor;
+                @OpenEditor.canceled -= m_Wrapper.m_KeyboardMouseActionsCallbackInterface.OnOpenEditor;
+            }
+            m_Wrapper.m_KeyboardMouseActionsCallbackInterface = instance;
+            if (instance != null)
+            {
+                @ReloadScript.started += instance.OnReloadScript;
+                @ReloadScript.performed += instance.OnReloadScript;
+                @ReloadScript.canceled += instance.OnReloadScript;
+                @OpenEditor.started += instance.OnOpenEditor;
+                @OpenEditor.performed += instance.OnOpenEditor;
+                @OpenEditor.canceled += instance.OnOpenEditor;
+            }
+        }
+    }
+    public KeyboardMouseActions @KeyboardMouse => new KeyboardMouseActions(this);
+    public interface IKeyboardMouseActions
+    {
+        void OnReloadScript(InputAction.CallbackContext context);
+        void OnOpenEditor(InputAction.CallbackContext context);
+    }
+}

--- a/unity-ggjj/Assets/Scripts/Input/DebugControls.cs.meta
+++ b/unity-ggjj/Assets/Scripts/Input/DebugControls.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 624dc0d0445f24e429d0113ad0d9e60c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Scripts/Input/DebugControls.inputactions
+++ b/unity-ggjj/Assets/Scripts/Input/DebugControls.inputactions
@@ -1,0 +1,74 @@
+{
+    "name": "DebugControls",
+    "maps": [
+        {
+            "name": "Keyboard/Mouse",
+            "id": "40c3f060-180e-43d6-981b-b4ece39e00eb",
+            "actions": [
+                {
+                    "name": "ReloadScript",
+                    "type": "Button",
+                    "id": "948de251-4bce-431b-b749-fa13b7c4499b",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "OpenEditor",
+                    "type": "Button",
+                    "id": "dce34266-8a6c-4591-a6e9-d2e1fa6dca54",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "d75864a1-7b83-4223-bbda-c15887431023",
+                    "path": "<Keyboard>/r",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "ReloadScript",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "Button With One Modifier",
+                    "id": "6989c641-2aa1-4c80-9640-99fc81755009",
+                    "path": "ButtonWithOneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "OpenEditor",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "cd357d8f-24b0-477a-80bd-7bf1653f4940",
+                    "path": "<Keyboard>/ctrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "OpenEditor",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "button",
+                    "id": "1560bb35-bd93-4f6d-93f6-283feb1179f8",
+                    "path": "<Keyboard>/r",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "OpenEditor",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                }
+            ]
+        }
+    ],
+    "controlSchemes": []
+}

--- a/unity-ggjj/Assets/Scripts/Input/DebugControls.inputactions.meta
+++ b/unity-ggjj/Assets/Scripts/Input/DebugControls.inputactions.meta
@@ -1,0 +1,14 @@
+fileFormatVersion: 2
+guid: e5c3beadbf7f28a41b8432f2477155e9
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 8404be70184654265930450def6a9037, type: 3}
+  generateWrapperCode: 1
+  wrapperCodePath: 
+  wrapperClassName: 
+  wrapperCodeNamespace: 

--- a/unity-ggjj/Assets/Scripts/RuntimeEditing.meta
+++ b/unity-ggjj/Assets/Scripts/RuntimeEditing.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f7d41db7f8dc4ee389506c9b340ef96b
+timeCreated: 1679169503

--- a/unity-ggjj/Assets/Scripts/RuntimeEditing/NarrativeScriptWatcher.cs
+++ b/unity-ggjj/Assets/Scripts/RuntimeEditing/NarrativeScriptWatcher.cs
@@ -1,0 +1,101 @@
+using System.IO;
+using UnityEngine;
+
+namespace RuntimeEditing
+{
+    // Creates and watches a .ink file and restarts the game 
+    public class NarrativeScriptWatcher : MonoBehaviour
+    {
+        [SerializeField]
+        private NarrativeGameState narrativeGameState;
+        private DebugControls _debugControls;
+        private string _absolutePathToScript;
+        private string _absolutePathToCompiledScript;
+        private FileSystemWatcher _fileSystemWatcher;
+        private bool _fileHasChanged;
+
+        private void Awake()
+        {
+            if (!Debug.isDebugBuild) 
+            {
+                Destroy(this.gameObject);
+                return;
+            }
+        
+            const string RELATIVE_SCRIPT_PATH = "/../DevKit/Script.ink";
+            _absolutePathToScript = Path.GetFullPath(Application.dataPath + RELATIVE_SCRIPT_PATH);
+            const string RELATIVE_COMPILATION_TARGET_PATH = "/../Temp/Script.ink.json";
+            _absolutePathToCompiledScript = Path.GetFullPath(Application.dataPath + RELATIVE_COMPILATION_TARGET_PATH);
+        
+            narrativeGameState = GetComponent<NarrativeGameState>();
+            _debugControls = new DebugControls();
+            _debugControls.Enable();
+            _debugControls.KeyboardMouse.ReloadScript.performed += _ =>
+            {
+                Debug.Log($"{nameof(NarrativeScriptWatcher)}: Explicit reload request");
+                ReloadGame();
+            };
+
+            _debugControls.KeyboardMouse.OpenEditor.performed += _ =>
+            {
+                Debug.Log($"{nameof(NarrativeScriptWatcher)}: Opening '{_absolutePathToScript}'");
+                var process = new System.Diagnostics.Process();
+                process.StartInfo.FileName = _absolutePathToScript;
+                process.Start();
+            };
+        
+            if (!File.Exists(_absolutePathToScript))
+            {
+                File.Create(_absolutePathToScript);
+            }
+        
+            _fileSystemWatcher = new FileSystemWatcher();
+            _fileSystemWatcher.Path = Directory.GetParent(_absolutePathToScript)!.FullName;
+            _fileSystemWatcher.Filter = Path.GetFileName(_absolutePathToScript);
+            _fileSystemWatcher.IncludeSubdirectories = false;
+            _fileSystemWatcher.NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.Size | NotifyFilters.LastWrite;
+            _fileSystemWatcher.Changed += (sender, args) =>
+            {
+                _fileHasChanged = true;
+            };
+            _fileSystemWatcher.EnableRaisingEvents = true;
+            Debug.Log($"{nameof(NarrativeScriptWatcher)}: Watching '{_absolutePathToScript}'...");
+        }
+
+        private void Update()
+        {
+            if (!_fileHasChanged)
+            {
+                return;
+            }
+
+            _fileHasChanged = false;
+            Debug.Log($"{nameof(NarrativeScriptWatcher)}: Change detected: '{_absolutePathToScript}'");  
+            ReloadGame();
+        }
+
+        private void ReloadGame()
+        {
+            if (!Directory.Exists(Application.dataPath + "/../Temp"))
+            {
+                Directory.CreateDirectory(Application.dataPath + "/../Temp");
+            }
+
+            Debug.Log($"{nameof(NarrativeScriptWatcher)}: Compiling debug script to '{_absolutePathToCompiledScript}'");
+            var compiler = new Ink.Compiler(File.ReadAllText(_absolutePathToScript));
+            var output = compiler.Compile().ToJson();
+            File.WriteAllText(_absolutePathToCompiledScript, output);
+
+            Debug.Log($"{nameof(NarrativeScriptWatcher)}: Restarting game...");
+            var narrativeScript = new NarrativeScript(new TextAsset(File.ReadAllText(_absolutePathToCompiledScript)));
+            narrativeGameState.ActorController.SetActiveSpeakerToNarrator();
+            narrativeGameState.SceneController.FadeIn(0);
+            narrativeGameState.NarrativeScriptStorage.NarrativeScript = narrativeScript;
+            narrativeGameState.EvidenceController.ClearCourtRecord();
+            narrativeGameState.NarrativeScriptPlayerComponent.NarrativeScriptPlayer.ActiveNarrativeScript = narrativeScript;
+            narrativeGameState.BGSceneList.ClearBGScenes();
+            narrativeGameState.BGSceneList.InstantiateBGScenes(narrativeScript);
+            narrativeGameState.SceneController.ReloadScene();
+        }
+    }
+}

--- a/unity-ggjj/Assets/Scripts/RuntimeEditing/NarrativeScriptWatcher.cs
+++ b/unity-ggjj/Assets/Scripts/RuntimeEditing/NarrativeScriptWatcher.cs
@@ -1,5 +1,8 @@
 using System.IO;
+using System.Text.RegularExpressions;
 using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.TestTools;
 
 namespace RuntimeEditing
 {
@@ -8,11 +11,41 @@ namespace RuntimeEditing
     {
         [SerializeField]
         private NarrativeGameState narrativeGameState;
+        public string AbsolutePathToWatchedScript { get; private set; }
+
         private DebugControls _debugControls;
-        private string _absolutePathToScript;
         private string _absolutePathToCompiledScript;
         private FileSystemWatcher _fileSystemWatcher;
         private bool _fileHasChanged;
+        
+        private readonly string _exampleScript = @"
+                &SCENE:TMPH_Court
+                &SET_ACTOR_POSITION:Defense,Arin
+                &SET_ACTOR_POSITION:Witness,Ross
+
+                &JUMP_TO_POSITION:Defense
+                &SPEAK:Arin
+                Okay, so you claim to have seen my client at the scene of the crime, and you base your entire testimony on a game of Mario Party?
+
+                &JUMP_TO_POSITION:Witness
+                &SPEAK:Ross
+                Yes, that's correct.
+
+                &JUMP_TO_POSITION:Defense
+                &SPEAK:Arin
+                And yet, you're the same person who made those incredibly difficult Mario Maker levels that almost broke me?
+
+                &JUMP_TO_POSITION:Witness
+                &SPEAK:Ross
+                Uh, yeah? Also what does that have to do with anything?
+
+                &JUMP_TO_POSITION:Defense
+                &SPEAK:Arin
+                Well, maybe look at what the writers of this script came up with!
+                ...
+                Absolutely nothing.
+                Good.
+                I am glad.".Replace("  ", "").Trim();
 
         private void Awake()
         {
@@ -23,11 +56,10 @@ namespace RuntimeEditing
             }
         
             const string RELATIVE_SCRIPT_PATH = "/../DevKit/Script.ink";
-            _absolutePathToScript = Path.GetFullPath(Application.dataPath + RELATIVE_SCRIPT_PATH);
+            AbsolutePathToWatchedScript = Path.GetFullPath(Application.dataPath + RELATIVE_SCRIPT_PATH);
             const string RELATIVE_COMPILATION_TARGET_PATH = "/../Temp/Script.ink.json";
             _absolutePathToCompiledScript = Path.GetFullPath(Application.dataPath + RELATIVE_COMPILATION_TARGET_PATH);
         
-            narrativeGameState = GetComponent<NarrativeGameState>();
             _debugControls = new DebugControls();
             _debugControls.Enable();
             _debugControls.KeyboardMouse.ReloadScript.performed += _ =>
@@ -36,22 +68,18 @@ namespace RuntimeEditing
                 ReloadGame();
             };
 
-            _debugControls.KeyboardMouse.OpenEditor.performed += _ =>
-            {
-                Debug.Log($"{nameof(NarrativeScriptWatcher)}: Opening '{_absolutePathToScript}'");
-                var process = new System.Diagnostics.Process();
-                process.StartInfo.FileName = _absolutePathToScript;
-                process.Start();
-            };
+            _debugControls.KeyboardMouse.OpenEditor.performed += OpenTextEditorForScript;
         
-            if (!File.Exists(_absolutePathToScript))
+            if (!File.Exists(AbsolutePathToWatchedScript))
             {
-                File.Create(_absolutePathToScript);
+                using var stream = File.Open(AbsolutePathToWatchedScript, FileMode.Create, FileAccess.Write);
+                using var writer = new StreamWriter(stream);
+                writer.Write(_exampleScript);
             }
         
             _fileSystemWatcher = new FileSystemWatcher();
-            _fileSystemWatcher.Path = Directory.GetParent(_absolutePathToScript)!.FullName;
-            _fileSystemWatcher.Filter = Path.GetFileName(_absolutePathToScript);
+            _fileSystemWatcher.Path = Directory.GetParent(AbsolutePathToWatchedScript)!.FullName;
+            _fileSystemWatcher.Filter = Path.GetFileName(AbsolutePathToWatchedScript);
             _fileSystemWatcher.IncludeSubdirectories = false;
             _fileSystemWatcher.NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.Size | NotifyFilters.LastWrite;
             _fileSystemWatcher.Changed += (sender, args) =>
@@ -59,7 +87,23 @@ namespace RuntimeEditing
                 _fileHasChanged = true;
             };
             _fileSystemWatcher.EnableRaisingEvents = true;
-            Debug.Log($"{nameof(NarrativeScriptWatcher)}: Watching '{_absolutePathToScript}'...");
+            Debug.Log($"{nameof(NarrativeScriptWatcher)}: Watching '{AbsolutePathToWatchedScript}'...");
+        }
+
+        [ExcludeFromCoverage]
+        private void OpenTextEditorForScript(InputAction.CallbackContext _)
+        {
+            Debug.Log($"{nameof(NarrativeScriptWatcher)}: Opening '{AbsolutePathToWatchedScript}'");
+            var process = new System.Diagnostics.Process();
+            process.StartInfo.FileName = AbsolutePathToWatchedScript;
+            process.Start();
+        }
+
+        private void OnDestroy()
+        {
+            _debugControls?.Dispose();
+            _fileSystemWatcher.EnableRaisingEvents = false;
+            _fileSystemWatcher?.Dispose();
         }
 
         private void Update()
@@ -70,7 +114,7 @@ namespace RuntimeEditing
             }
 
             _fileHasChanged = false;
-            Debug.Log($"{nameof(NarrativeScriptWatcher)}: Change detected: '{_absolutePathToScript}'");  
+            Debug.Log($"{nameof(NarrativeScriptWatcher)}: Change detected: '{AbsolutePathToWatchedScript}'");  
             ReloadGame();
         }
 
@@ -82,9 +126,25 @@ namespace RuntimeEditing
             }
 
             Debug.Log($"{nameof(NarrativeScriptWatcher)}: Compiling debug script to '{_absolutePathToCompiledScript}'");
-            var compiler = new Ink.Compiler(File.ReadAllText(_absolutePathToScript));
-            var output = compiler.Compile().ToJson();
-            File.WriteAllText(_absolutePathToCompiledScript, output);
+            Ink.Compiler compiler;
+            _fileSystemWatcher.EnableRaisingEvents = false;
+            using (var stream = File.Open(AbsolutePathToWatchedScript, FileMode.Open, FileAccess.Read))
+            {
+                using (var reader = new StreamReader(stream))
+                {
+                    compiler = new Ink.Compiler(reader.ReadToEnd());
+                    compiler.Compile();
+                }
+            }
+            _fileSystemWatcher.EnableRaisingEvents = true;
+
+            using (var stream = File.Open(_absolutePathToCompiledScript, FileMode.Create, FileAccess.Write))
+            {
+                using (var writer = new StreamWriter(stream))
+                {
+                    writer.Write(compiler.Compile().ToJson());
+                }
+            }
 
             Debug.Log($"{nameof(NarrativeScriptWatcher)}: Restarting game...");
             var narrativeScript = new NarrativeScript(new TextAsset(File.ReadAllText(_absolutePathToCompiledScript)));

--- a/unity-ggjj/Assets/Scripts/RuntimeEditing/NarrativeScriptWatcher.cs
+++ b/unity-ggjj/Assets/Scripts/RuntimeEditing/NarrativeScriptWatcher.cs
@@ -72,6 +72,11 @@ namespace RuntimeEditing
         
             if (!File.Exists(AbsolutePathToWatchedScript))
             {
+                if (!Directory.Exists(Path.GetDirectoryName(AbsolutePathToWatchedScript)!))
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(AbsolutePathToWatchedScript)!);
+                }
+                        
                 using var stream = File.Open(AbsolutePathToWatchedScript, FileMode.Create, FileAccess.Write);
                 using var writer = new StreamWriter(stream);
                 writer.Write(_exampleScript);

--- a/unity-ggjj/Assets/Scripts/RuntimeEditing/NarrativeScriptWatcher.cs
+++ b/unity-ggjj/Assets/Scripts/RuntimeEditing/NarrativeScriptWatcher.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Text.RegularExpressions;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.TestTools;
@@ -87,7 +86,7 @@ namespace RuntimeEditing
             _fileSystemWatcher.Filter = Path.GetFileName(AbsolutePathToWatchedScript);
             _fileSystemWatcher.IncludeSubdirectories = false;
             _fileSystemWatcher.NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.Size | NotifyFilters.LastWrite;
-            _fileSystemWatcher.Changed += (sender, args) =>
+            _fileSystemWatcher.Changed += (_, _) =>
             {
                 _fileHasChanged = true;
             };

--- a/unity-ggjj/Assets/Scripts/RuntimeEditing/NarrativeScriptWatcher.cs.meta
+++ b/unity-ggjj/Assets/Scripts/RuntimeEditing/NarrativeScriptWatcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 665a068ae74cc6944822fe633c5fab62
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/RuntimeEditingTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/RuntimeEditingTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using RuntimeEditing;
+using Tests.PlayModeTests.Tools;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+using Object = UnityEngine.Object;
+
+namespace Tests.PlayModeTests.Scripts
+{
+    public class RuntimeEditingTests
+    {
+        private readonly StoryProgresser _storyProgresser = new();
+
+        private Animator _witnessAnimator;
+
+        private global::AppearingDialogueController _appearingDialogueController;
+        private NarrativeScriptWatcher _narrativeScriptWatcher;
+        private Keyboard Keyboard => _storyProgresser.keyboard;
+
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+            _storyProgresser.Setup();
+            SceneManager.LoadScene("Game");
+            yield return null;
+            
+            _appearingDialogueController = Object.FindObjectOfType<global::AppearingDialogueController>();
+            _narrativeScriptWatcher = Object.FindObjectOfType<NarrativeScriptWatcher>();
+
+            TestTools.StartGame("ActorControllerTestScript");
+        }
+
+        [UnityTearDown]
+        public void UnityTearDown()
+        {
+            _storyProgresser.TearDown();
+        }
+
+        [UnityTest]
+        public IEnumerator SceneReloadCreatedScriptIfMissing()
+        {
+            Debug.Log($"Clearing {_narrativeScriptWatcher.AbsolutePathToWatchedScript}...");
+            File.Delete(_narrativeScriptWatcher.AbsolutePathToWatchedScript);
+            Assert.IsFalse(File.Exists(_narrativeScriptWatcher.AbsolutePathToWatchedScript));
+            
+            SceneManager.LoadScene("Game");
+            yield return null;
+            
+            _appearingDialogueController = Object.FindObjectOfType<global::AppearingDialogueController>();
+            _narrativeScriptWatcher = Object.FindObjectOfType<NarrativeScriptWatcher>();
+
+            TestTools.StartGame("ActorControllerTestScript");
+            Assert.IsTrue(File.Exists(_narrativeScriptWatcher.AbsolutePathToWatchedScript));
+        }
+
+        [UnityTest]
+        public IEnumerator FileChangeReloadsScene()
+        {
+            const string TEXT_CONTENT = @"
+                &SCENE:TMPH_Court
+                &SET_ACTOR_POSITION:Defense,Ross
+                &SET_ACTOR_POSITION:Witness,Arin
+
+                &JUMP_TO_POSITION:Defense
+                &SPEAK:Arin
+                I'm visible!";
+            var normalizedTextContent = TEXT_CONTENT
+                                                 .Replace("\n", Environment.NewLine)
+                                                 .Replace("\r", Environment.NewLine)
+                                                 .Replace(Environment.NewLine+ Environment.NewLine, Environment.NewLine);
+            
+            yield return _storyProgresser.ProgressStory();
+            Assert.AreNotEqual(normalizedTextContent.Split(Environment.NewLine).Last(), _appearingDialogueController.Text);
+            
+            File.WriteAllText(_narrativeScriptWatcher.AbsolutePathToWatchedScript, normalizedTextContent);
+            yield return TestTools.WaitForState(() => normalizedTextContent.Split(Environment.NewLine).Last().Trim() == Object.FindObjectOfType<global::AppearingDialogueController>().Text);
+        }
+
+        [UnityTest]
+        public IEnumerator ManualKeyboardShortcutReloadsScene()
+        {
+            yield return _storyProgresser.ProgressStory();
+            var textBeforeReload = _appearingDialogueController.Text;
+            yield return _storyProgresser.PressForFrame(Keyboard.rKey);
+            yield return TestTools.WaitForState(() => textBeforeReload != Object.FindObjectOfType<global::AppearingDialogueController>().Text);
+        }
+    }
+}

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/RuntimeEditingTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/RuntimeEditingTests.cs
@@ -20,18 +20,28 @@ namespace Tests.PlayModeTests.Scripts
         private Keyboard Keyboard => _storyProgresser.keyboard;
         
         private NarrativeScriptWatcher _narrativeScriptWatcher;
+        
+        [SetUp]
+        public void Setup()
+        {
+            _storyProgresser.Setup();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _storyProgresser.TearDown();
+        }
 
         [UnitySetUp]
         public IEnumerator UnitySetUp()
         {
-            _storyProgresser.Setup();
-            SceneManager.LoadScene("Game");
-            yield return null;
+            yield return SceneManager.LoadSceneAsync("Game");
+
+            TestTools.StartGame("ActorControllerTestScript");
             
             _appearingDialogueController = Object.FindObjectOfType<global::AppearingDialogueController>();
             _narrativeScriptWatcher = Object.FindObjectOfType<NarrativeScriptWatcher>();
-
-            TestTools.StartGame("ActorControllerTestScript");
         }
 
         [UnityTearDown]

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/RuntimeEditingTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/RuntimeEditingTests.cs
@@ -46,7 +46,8 @@ namespace Tests.PlayModeTests.Scripts
         public IEnumerator SceneReloadCreatedScriptIfMissing()
         {
             Debug.Log($"Clearing {_narrativeScriptWatcher.AbsolutePathToWatchedScript}...");
-            File.Delete(_narrativeScriptWatcher.AbsolutePathToWatchedScript);
+            Directory.Delete(Path.GetDirectoryName(_narrativeScriptWatcher.AbsolutePathToWatchedScript)!, true);
+            
             Assert.IsFalse(File.Exists(_narrativeScriptWatcher.AbsolutePathToWatchedScript));
             
             SceneManager.LoadScene("Game");

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/RuntimeEditingTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/RuntimeEditingTests.cs
@@ -15,13 +15,11 @@ namespace Tests.PlayModeTests.Scripts
 {
     public class RuntimeEditingTests
     {
-        private readonly StoryProgresser _storyProgresser = new();
-
-        private Animator _witnessAnimator;
-
         private global::AppearingDialogueController _appearingDialogueController;
-        private NarrativeScriptWatcher _narrativeScriptWatcher;
+        private readonly StoryProgresser _storyProgresser = new();
         private Keyboard Keyboard => _storyProgresser.keyboard;
+        
+        private NarrativeScriptWatcher _narrativeScriptWatcher;
 
         [UnitySetUp]
         public IEnumerator UnitySetUp()

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/RuntimeEditingTests.cs.meta
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Scripts/RuntimeEditingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 077d5f7511a82174ea336477e6fdc408
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/ProjectSettings/BurstAotSettings_StandaloneWindows.json
+++ b/unity-ggjj/ProjectSettings/BurstAotSettings_StandaloneWindows.json
@@ -1,0 +1,16 @@
+{
+  "MonoBehaviour": {
+    "Version": 4,
+    "EnableBurstCompilation": true,
+    "EnableOptimisations": true,
+    "EnableSafetyChecks": false,
+    "EnableDebugInAllBuilds": false,
+    "CpuMinTargetX32": 0,
+    "CpuMaxTargetX32": 0,
+    "CpuMinTargetX64": 0,
+    "CpuMaxTargetX64": 0,
+    "CpuTargetsX32": 6,
+    "CpuTargetsX64": 72,
+    "OptimizeFor": 0
+  }
+}

--- a/unity-ggjj/ProjectSettings/CommonBurstAotSettings.json
+++ b/unity-ggjj/ProjectSettings/CommonBurstAotSettings.json
@@ -1,0 +1,6 @@
+{
+  "MonoBehaviour": {
+    "Version": 4,
+    "DisabledWarnings": ""
+  }
+}

--- a/unity-ggjj/ProjectSettings/ProjectSettings.asset
+++ b/unity-ggjj/ProjectSettings/ProjectSettings.asset
@@ -147,6 +147,7 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1

--- a/unity-ggjj/ProjectSettings/ProjectSettings.asset
+++ b/unity-ggjj/ProjectSettings/ProjectSettings.asset
@@ -146,6 +146,7 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1
@@ -381,6 +382,7 @@ PlayerSettings:
       m_Kind: 0
       m_SubKind: 
   m_BuildTargetBatching: []
+  m_BuildTargetShaderSettings: []
   m_BuildTargetGraphicsJobs:
   - m_BuildTarget: MacStandaloneSupport
     m_GraphicsJobs: 0
@@ -417,6 +419,8 @@ PlayerSettings:
     m_APIs: 10000000
     m_Automatic: 1
   m_BuildTargetVRSettings: []
+  m_DefaultShaderChunkSizeInMB: 16
+  m_DefaultShaderChunkCount: 0
   openGLRequireES31: 0
   openGLRequireES31AEP: 0
   openGLRequireES32: 0
@@ -580,6 +584,7 @@ PlayerSettings:
   switchNetworkInterfaceManagerInitializeEnabled: 1
   switchPlayerConnectionEnabled: 1
   switchUseNewStyleFilepaths: 0
+  switchUseLegacyFmodPriorities: 0
   switchUseMicroSleepForYield: 1
   switchEnableRamDiskSupport: 0
   switchMicroSleepForYieldTime: 25
@@ -685,6 +690,7 @@ PlayerSettings:
   webGLMemoryLinearGrowthStep: 16
   webGLMemoryGeometricGrowthStep: 0.2
   webGLMemoryGeometricGrowthCap: 96
+  webGLPowerPreference: 2
   scriptingDefineSymbols: {}
   additionalCompilerArguments: {}
   platformArchitecture: {}


### PR DESCRIPTION
## Summary
NarrativeScripts are purely text-based. To make it easier to edit them, the game can now open a text editor with an example script and will automatically load and play the script when the file is saved.

## Before/after screenshots and/or animated gif
![Game_Grumps_-_Joint_Justice_DXJegeNwe1](https://user-images.githubusercontent.com/1689033/226142481-5dd7254a-43ab-4f0d-8823-f56619dfe055.gif)

## Testing instructions
### Runtime editing usage
1. Open the main menu in the editor or start a pre-compiled binary of the game
2. Start the game normally
3. Press Ctrl+R
4. Notice a text editor opening an Ink script
5. Notice the game starting to play that exact Ink script
6. Change the script in the text editor and save it
7. Notice the game automatically reloading
8. Run the added PlayModeTests
9. Check [the updated wiki page](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/wiki/Scripting-Basics-using-Inky#overview)

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[x]` Introduces new feature
  - Runtime editing of scripts
- `[ ]` Removes existing feature
- `[ ]` Has associated resource: 
