### PR TITLE
Skipping dialogue no longer plays any sound and ends the entire line

### DIFF
--- a/unity-ggjj/Assets/Scripts/UI/AppearingDialogueController/AppearingDialogueController.cs
+++ b/unity-ggjj/Assets/Scripts/UI/AppearingDialogueController/AppearingDialogueController.cs
@@ -142,6 +142,12 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
         IsPrintingText = true;
         for (int i = startingIndex; i < _textInfo.characterCount; i++)
         {
+            if (SpeedupText)
+            {
+                _textBox.maxVisibleCharacters = _textInfo.characterCount;
+                EndLine();
+                yield break;
+            }
             _textBox.maxVisibleCharacters++;
             var currentCharacterInfo = _textInfo.characterInfo[_textBox.maxVisibleCharacters - 1];
             TryPlayDialogueChirp(_namebox.CurrentActorDialogueChirp, currentCharacterInfo);


### PR DESCRIPTION
## Summary
See #372

## Testing instructions
See #372

## Additional information
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[X]` Has associated resource:
  - Closes #372
