### PR TITLE
Explosion sound effect when receiving a penalty

### DIFF
--- a/unity-ggjj/Assets/Scenes/Game.unity
+++ b/unity-ggjj/Assets/Scenes/Game.unity
@@ -2480,6 +2480,10 @@ PrefabInstance:
       value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 7962780514542778033, guid: f4cda231489f65341910a0acac208946, type: 3}
+      propertyPath: _penaltyAudioClip
+      value: 
+      objectReference: {fileID: 8300000, guid: 16967893638c5084fa08e7519deff9b6, type: 3}
+    - target: {fileID: 7962780514542778033, guid: f4cda231489f65341910a0acac208946, type: 3}
       propertyPath: _narrativeGameState
       value: 
       objectReference: {fileID: 7963640705624872190}

--- a/unity-ggjj/Assets/Scripts/UI/AppearingDialogueController/AppearingDialogueController.cs
+++ b/unity-ggjj/Assets/Scripts/UI/AppearingDialogueController/AppearingDialogueController.cs
@@ -142,12 +142,6 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
         IsPrintingText = true;
         for (int i = startingIndex; i < _textInfo.characterCount; i++)
         {
-            if (SpeedupText)
-            {
-                _textBox.maxVisibleCharacters = _textInfo.characterCount;
-                EndLine();
-                yield break;
-            }
             _textBox.maxVisibleCharacters++;
             var currentCharacterInfo = _textInfo.characterInfo[_textBox.maxVisibleCharacters - 1];
             TryPlayDialogueChirp(_namebox.CurrentActorDialogueChirp, currentCharacterInfo);
@@ -182,7 +176,7 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
         {
             resultChirp = _defaultDialogueChirpSfx;
         }
-        
+
         if (_chirpIndex % _chirpEveryNthLetter == 0)
         {
             _narrativeGameState.AudioController.PlayDialogueChirp(resultChirp);

--- a/unity-ggjj/Assets/Scripts/UI/AppearingDialogueController/AppearingDialogueController.cs
+++ b/unity-ggjj/Assets/Scripts/UI/AppearingDialogueController/AppearingDialogueController.cs
@@ -142,6 +142,12 @@ public class AppearingDialogueController : MonoBehaviour, IAppearingDialogueCont
         IsPrintingText = true;
         for (int i = startingIndex; i < _textInfo.characterCount; i++)
         {
+            if (SpeedupText)
+            {
+                _textBox.maxVisibleCharacters = _textInfo.characterCount;
+                EndLine();
+                yield break;
+            }
             _textBox.maxVisibleCharacters++;
             var currentCharacterInfo = _textInfo.characterInfo[_textBox.maxVisibleCharacters - 1];
             TryPlayDialogueChirp(_namebox.CurrentActorDialogueChirp, currentCharacterInfo);

--- a/unity-ggjj/Assets/Scripts/UI/PenaltyManager.cs
+++ b/unity-ggjj/Assets/Scripts/UI/PenaltyManager.cs
@@ -10,6 +10,7 @@ public class PenaltyManager : MonoBehaviour, IPenaltyManager
     [SerializeField]private Animator _penaltyObject;
 
     [SerializeField] private int _penaltyCount = 5;
+    [SerializeField] private AudioClip _penaltyAudioClip;
 
     private readonly Queue<Animator> _penaltyObjects = new Queue<Animator>();
 
@@ -59,6 +60,7 @@ public class PenaltyManager : MonoBehaviour, IPenaltyManager
         Debug.Assert(PenaltiesLeft > 0, "Decrement must not be called with 0 or fewer penalty lifelines left");
         PenaltiesLeft--;
         _penaltyObjects.Dequeue().Play("Explosion");
+        _narrativeGameState.AudioController.PlaySfx(_penaltyAudioClip);
         if (PenaltiesLeft == 0)
         {
             _narrativeGameState.NarrativeScriptPlayerComponent.NarrativeScriptPlayer.ActiveNarrativeScriptPlayer.OnNarrativeScriptComplete += OnNoLivesLeft;

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Tools/StoryProgresser.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Tools/StoryProgresser.cs
@@ -64,7 +64,7 @@ namespace Tests.PlayModeTests.Tools
                 yield break;
             }
             
-            // Check if the item being presented in an actor
+            // Check if the item being presented is an actor
             if (courtRecordObjects.Any(courtRecordObject => courtRecordObject is ActorData && courtRecordObject.InstanceName == evidenceName))
             {
                 yield return PressForFrame(keyboard.cKey);


### PR DESCRIPTION
## Summary
The Penalty Manager now has a `_penaltyAudioClip` serialized field and plays the selected audio clip when receiving a penalty.
We can remove the field if we don't need any customization in the future and only want to hard-code "Damage2" to play, I just wanted to be thorough :)

p.s. don't bother with the AppearingDialogueController change, i had leftover code from another branch and forgot to checkout to develop before creating this one.

## Testing instructions
 - Start debug script 1-7-RossCrossExamination2
 - Present anything other than the Plumber's Invoice

## Additional information
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[X]` Has associated resource: 
  - Closes #377
