### PR TITLE
Bumps docs_generator from .NET 7 to .NET 8

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
       
       - name: Build docs generator
         working-directory: ./docs_generator
@@ -36,7 +36,7 @@ jobs:
        
       - name: Execute docs runner 
         working-directory: ./unity-ggjj
-        run: ../docs_generator/bin/Debug/net7.0/Scanner
+        run: ../docs_generator/bin/Debug/net8.0/Scanner
 
       - name: Generate new state of docs
         id: newDocs

--- a/docs_generator/Scanner.csproj
+++ b/docs_generator/Scanner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <StartupObject>Scanner.Scanner</StartupObject>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
[.NET 8 just got released](https://devblogs.microsoft.com/dotnet/announcing-dotnet-8-rc1/), might as well bump the version for the documentation generator.

## Testing instructions
1. Follow the steps in the wiki to [regenerate documentation](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/wiki/Automated-Documentation-Generation#making-changes-to-the-generator-and-running-it-locally)
2. Ensure that both:
    1. documentation **isn't** updated, **if there are no** changes warranting an update to the documentation
    2. documentation **is** updated, **if there are changes** warranting an update to the documentation

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[ ]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->
