### PR TITLE
Adds `in-line action` example

### DIFF
--- a/docs/methods/Dialogue.md
+++ b/docs/methods/Dialogue.md
@@ -56,6 +56,22 @@ Makes the next dialogue add to the current one instead of replacing it.
 
 Examples: 
   - `&CONTINUE_DIALOGUE`
+  - ```
+    &ACTOR:Dan
+    &SPEAK:Dan
+    This script tests mid sentence actions.
+    &AUTO_SKIP:true
+    Half-way through this sentence I will
+    &CONTINUE_DIALOGUE
+    &SHAKE_SCREEN:0.2,0.2,false
+    &PLAY_SFX:Thud3
+    &SET_POSE:Lean
+    COUGH
+    &CONTINUE_DIALOGUE
+    &SET_POSE:Normal
+    &AUTO_SKIP:false
+    and the screen will shake.
+    ```
 
 ## APPEAR_INSTANTLY
 

--- a/docs_generator/Scanner.cs
+++ b/docs_generator/Scanner.cs
@@ -111,12 +111,10 @@ public class Scanner
         return string.Join("\n\n", methods.Select(method => GenerateTextForMethod(method, complexTypes)));
     }
     
-    private static string FormatExampleBasedOnNewlines(string example)
-    {
-return example.Contains('\n')) 
-    ? $"  - ```\n{string.Join("\n", example.Split("\n").Select(line => $"    {line}"))}\n    ```"
-    : $"  - `{example}`";
-    }
+    private static string FormatExampleBasedOnNewlines(string example) =>
+        example.Contains('\n')
+            ? $"  - ```\n{string.Join("\n", example.Split("\n").Select(line => $"    {line}"))}\n    ```"
+            : $"  - `{example}`";
 
     private static string GenerateTextForMethod(MethodInfo methodInfo, IEnumerable<string> complexTypes)
     {

--- a/docs_generator/Scanner.cs
+++ b/docs_generator/Scanner.cs
@@ -113,11 +113,9 @@ public class Scanner
     
     private static string FormatExampleBasedOnNewlines(string example)
     {
-        if (!example.Contains('\n'))
-        {
-            return $"  - `{example}`";
-        }
-        return $"  - ```\n{string.Join("\n", example.Split("\n").Select(line => $"    {line}"))}\n    ```";
+return example.Contains('\n')) 
+    ? $"  - ```\n{string.Join("\n", example.Split("\n").Select(line => $"    {line}"))}\n    ```"
+    : $"  - `{example}`";
     }
 
     private static string GenerateTextForMethod(MethodInfo methodInfo, IEnumerable<string> complexTypes)

--- a/docs_generator/Scanner.cs
+++ b/docs_generator/Scanner.cs
@@ -110,6 +110,15 @@ public class Scanner
     {
         return string.Join("\n\n", methods.Select(method => GenerateTextForMethod(method, complexTypes)));
     }
+    
+    private static string FormatExampleBasedOnNewlines(string example)
+    {
+        if (!example.Contains('\n'))
+        {
+            return $"  - `{example}`";
+        }
+        return $"  - ```\n{string.Join("\n", example.Split("\n").Select(line => $"    {line}"))}\n    ```";
+    }
 
     private static string GenerateTextForMethod(MethodInfo methodInfo, IEnumerable<string> complexTypes)
     {
@@ -122,7 +131,7 @@ public class Scanner
             return $"  - {pair.Value.parameterComment}";
         }).ToList();
         var values = parameterInfo.Any() ? $"Values: \n{string.Join("\n", parameterInfo)}" + "\n" : "";
-        var example = $"Examples: \n{string.Join("\n", methodInfo.Examples.Select(example => $"  - `{example}`"))}";
+        var example = $"Examples: \n{string.Join("\n", methodInfo.Examples.Select(FormatExampleBasedOnNewlines))}";
         var description = $"{(methodInfo.IsInstant ? "⏲ Instant" : "⏳ Waits for completion")}\n\n{methodInfo.Summary}";
         return string.Join("\n", methodName, values, description, "", example);
     }

--- a/unity-ggjj/Assets/Scripts/TextDecoder/ActionDecoder.cs
+++ b/unity-ggjj/Assets/Scripts/TextDecoder/ActionDecoder.cs
@@ -60,6 +60,20 @@ public class ActionDecoder : ActionDecoderBase
 
     /// <summary>Makes the next dialogue add to the current one instead of replacing it.</summary>
     /// <example>&amp;CONTINUE_DIALOGUE</example>
+    /// <example>&amp;ACTOR:Dan
+    /// &amp;SPEAK:Dan
+    /// This script tests mid sentence actions.
+    /// &amp;AUTO_SKIP:true
+    /// Half-way through this sentence I will
+    /// &amp;CONTINUE_DIALOGUE
+    /// &amp;SHAKE_SCREEN:0.2,0.2,false
+    /// &amp;PLAY_SFX:Thud3
+    /// &amp;SET_POSE:Lean
+    /// COUGH
+    /// &amp;CONTINUE_DIALOGUE
+    /// &amp;SET_POSE:Normal
+    /// &amp;AUTO_SKIP:false
+    /// and the screen will shake.</example>
     /// <category>Dialogue</category>
     private void CONTINUE_DIALOGUE()
     {


### PR DESCRIPTION
## Summary
While developers can use `CONTINUE_DIALOGUE` to run action lines mid-dialogue (called in-line actions), the docs offered no reference for it. Resolved this in b8d5b92.

c37f33e also enhances support for multi-line examples in the docs generator. This code block courtesy of @PhoebeMitchell…
```csharp
/// <example>&amp;ACTOR:Dan
/// &amp;SPEAK:Dan
/// This script tests mid sentence actions.
/// &amp;AUTO_SKIP:true
/// Half-way through this sentence I will
/// &amp;CONTINUE_DIALOGUE
/// &amp;SHAKE_SCREEN:0.2,0.2,false
/// &amp;PLAY_SFX:Thud3
/// &amp;SET_POSE:Lean
/// COUGH
/// &amp;CONTINUE_DIALOGUE
/// &amp;SET_POSE:Normal
/// &amp;AUTO_SKIP:false
/// and the screen will shake.</example>
```
…previously resulted in…
```md
  - `&ACTOR:Dan
&SPEAK:Dan
This script tests mid sentence actions.
&AUTO_SKIP:true
Half-way through this sentence I will
&CONTINUE_DIALOGUE
&SHAKE_SCREEN:0.2,0.2,false
&PLAY_SFX:Thud3
&SET_POSE:Lean
COUGH
&CONTINUE_DIALOGUE
&SET_POSE:Normal
&AUTO_SKIP:false
and the screen will shake.`
```
…and now results in…
```md
  - ```
    &ACTOR:Dan
    &SPEAK:Dan
    This script tests mid sentence actions.
    &AUTO_SKIP:true
    Half-way through this sentence I will
    &CONTINUE_DIALOGUE
    &SHAKE_SCREEN:0.2,0.2,false
    &PLAY_SFX:Thud3
    &SET_POSE:Lean
    COUGH
    &CONTINUE_DIALOGUE
    &SET_POSE:Normal
    &AUTO_SKIP:false
    and the screen will shake.
    ```
```

## Testing instructions
Add b8d5b92, run the `docs_generator` before and after applying c37f33e, and notice the changes in documentation.

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[ ]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->
