### PR TITLE
Adds `Blink` FullscreenAnimation (no SFX) and demo script

### DIFF
--- a/docs/constants.md
+++ b/docs/constants.md
@@ -152,6 +152,7 @@
 
 ## FullscreenAnimationAssetName
   - BadBoy
+  - Blink
   - CrossExamination
   - GavelHit
   - GoodBoy

--- a/unity-ggjj/Assets/Animations/FullscreenAnimations/Blink.anim
+++ b/unity-ggjj/Assets/Animations/FullscreenAnimations/Blink.anim
@@ -1,0 +1,85 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Blink
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: -1310073579, guid: 58ffd8ab87372460b80cdaa4ea5685a4, type: 3}
+    - time: 0.016666668
+      value: {fileID: -1212332576, guid: 58ffd8ab87372460b80cdaa4ea5685a4, type: 3}
+    - time: 0.033333335
+      value: {fileID: 0}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -1310073579, guid: 58ffd8ab87372460b80cdaa4ea5685a4, type: 3}
+    - {fileID: -1212332576, guid: 58ffd8ab87372460b80cdaa4ea5685a4, type: 3}
+    - {fileID: 0}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.050000004
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events:
+  - time: 0.033333335
+    functionName: OnAnimationComplete
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/unity-ggjj/Assets/Animations/FullscreenAnimations/Blink.anim.meta
+++ b/unity-ggjj/Assets/Animations/FullscreenAnimations/Blink.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 815921128d0ec4da0a920045f299006a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/FullscreenAnimations/FullscreenAnimations.controller
+++ b/unity-ggjj/Assets/Animations/FullscreenAnimations/FullscreenAnimations.controller
@@ -74,6 +74,32 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1102 &-3205595986832928181
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Blink
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 815921128d0ec4da0a920045f299006a, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1102 &-2506509698905563298
 AnimatorState:
   serializedVersion: 6
@@ -175,6 +201,9 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: -6146909423710000221}
     m_Position: {x: 30, y: 290, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -3205595986832928181}
+    m_Position: {x: 30, y: 590, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []

--- a/unity-ggjj/Assets/Images/FullscreenAnimations/Blink.meta
+++ b/unity-ggjj/Assets/Images/FullscreenAnimations/Blink.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b645499e12c4a4c6c8ccac274c7a9588
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Images/FullscreenAnimations/Blink/Blink.png
+++ b/unity-ggjj/Assets/Images/FullscreenAnimations/Blink/Blink.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de3afc3650191ea91fe8dc7d55ea38ed17fe7a5e0c764b5d538ba8393aa67001
+size 195

--- a/unity-ggjj/Assets/Images/FullscreenAnimations/Blink/Blink.png.meta
+++ b/unity-ggjj/Assets/Images/FullscreenAnimations/Blink/Blink.png.meta
@@ -1,0 +1,171 @@
+fileFormatVersion: 2
+guid: 58ffd8ab87372460b80cdaa4ea5685a4
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 2
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites:
+    - serializedVersion: 2
+      name: Blink_0
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 180
+        width: 320
+        height: 180
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 67b5cb80456a5464b84096c108c00ac8
+      internalID: -1310073579
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Blink_1
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 0
+        width: 320
+        height: 180
+      alignment: 0
+      pivot: {x: 0, y: 0}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 1bcfce9f9c5594aaab3a71076e3fc835
+      internalID: -1212332576
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable:
+      Blink_0: -1310073579
+      Blink_1: -1212332576
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/Blink.ink
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/Blink.ink
@@ -1,0 +1,6 @@
+&SCENE:TMPHJudge
+&ACTOR:JudgeBrent
+&SPEAK:JudgeBrent
+...
+&PLAY_ANIMATION:Blink
+Wot?

--- a/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/Blink.ink.meta
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/Blink.ink.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5f47a7710fc04ba1b49b6e0bc68e99b7
+timeCreated: 1723325561

--- a/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/Blink.json
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/Blink.json
@@ -1,0 +1,1 @@
+﻿{"inkVersion":21,"root":[["^&SCENE:TMPHJudge","\n","^&ACTOR:JudgeBrent","\n","^&SPEAK:JudgeBrent","\n","^...","\n","^&PLAY_ANIMATION:Blink","\n","^Wot?","\n",["done",{"#f":5,"#n":"g-0"}],null],"done",{"#f":1}],"listDefs":{}}

--- a/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/Blink.json.meta
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/Blink.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 15fe7fe98d60f41c1aa5586da89606f0
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

Adds a blink with the same duration and color based on the original.

https://github.com/user-attachments/assets/8f4d8406-ed1a-436f-a74f-5d42d9d0b729

## Testing instructions
1. Open the `Game` scene
2. Load the `unity-ggjj/Assets/Tests/PlayModeTests/TestScripts/Blink.ink` script
3. Notice the blink animation

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[ ]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->
