### PR TITLE
Various findings as part of today's meeting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+**/.idea/*

--- a/docs/constants.md
+++ b/docs/constants.md
@@ -249,6 +249,7 @@
   - Angry
   - AngryTalking
   - Lean
+  - LeanTalking
   - Normal
   - NormalTalking
   - SideNormal

--- a/docs/constants.md
+++ b/docs/constants.md
@@ -16,9 +16,11 @@
 | ---- | ----------- | ---- |
 | Arin | Half of the Game Grumps duo. Definitely the same height as Dan. | ![image for Arin](../unity-ggjj/Assets/Images/Profiles/Arin.png) |
 | Baby | Marge. | ![image for Baby](../unity-ggjj/Assets/Images/Profiles/Baby.png) |
+| Burgie | Gently floating star of The Grump Cast. | ![image for Burgie](../unity-ggjj/Assets/Images/Profiles/Dan.png) |
 | Dan | The other half of the Game Grumps. Known aliases: 'Danny Sexbang', 'Mr. Business.' | ![image for Dan](../unity-ggjj/Assets/Images/Profiles/Dan.png) |
 | Jory | Game developer for Dream Daddy. Previous job: P.P.I.S.S machine. | ![image for Jory](../unity-ggjj/Assets/Images/Profiles/Jory.png) |
 | JudgeBrent | Manages the Grumps business. Also a Judge in the totally real Attitute City. | ![image for JudgeBrent](../unity-ggjj/Assets/Images/Profiles/JudgeBrent.png) |
+| Laura | Divorced. Lacking 3 toes. Not to be confused with Rachel, working for Fart Modeing. | ![image for Laura](../unity-ggjj/Assets/Images/Profiles/Dan.png) |
 | Ross | Animator and self-described sadist. Also really loves milk for some reason. | ![image for Ross](../unity-ggjj/Assets/Images/Profiles/Ross.png) |
 | TutorialBoy | The first prosecutor. Has an extremely predictable name. | ![image for TutorialBoy](../unity-ggjj/Assets/Images/Profiles/TutorialBoy.png) |
 
@@ -138,11 +140,13 @@
 | AttorneysBadge | My most valued possession. | ![image for AttorneysBadge](../unity-ggjj/Assets/Images/Evidence/AttorneyBadge.png) |
 | Baby | Marge. | ![image for Baby](../unity-ggjj/Assets/Images/Profiles/Baby.png) |
 | BentCoins | Jory's Good Boy Coins. They're scuffed and bent out of shape. | ![image for BentCoins](../unity-ggjj/Assets/Images/Evidence/BentCoins.png) |
+| Burgie | Gently floating star of The Grump Cast. | ![image for Burgie](../unity-ggjj/Assets/Images/Profiles/Dan.png) |
 | Dan | The other half of the Game Grumps. Known aliases: 'Danny Sexbang', 'Mr. Business.' | ![image for Dan](../unity-ggjj/Assets/Images/Profiles/Dan.png) |
 | Jory | Game developer for Dream Daddy. Previous job: P.P.I.S.S machine. | ![image for Jory](../unity-ggjj/Assets/Images/Profiles/Jory.png) |
 | JorysBackpack | The backpack that Jory keeps his Good Boy coins in. Seems unusually full of... something. | ![image for JorysBackpack](../unity-ggjj/Assets/Images/Evidence/JoryBackpack.png) |
 | JorySrsLetter | Letter from the real Jory Sr. | ![image for JorySrsLetter](../unity-ggjj/Assets/Images/Evidence/JorySrLetter.png) |
 | JudgeBrent | Manages the Grumps business. Also a Judge in the totally real Attitute City. | ![image for JudgeBrent](../unity-ggjj/Assets/Images/Profiles/JudgeBrent.png) |
+| Laura | Divorced. Lacking 3 toes. Not to be confused with Rachel, working for Fart Modeing. | ![image for Laura](../unity-ggjj/Assets/Images/Profiles/Dan.png) |
 | LivestreamRecording | A record of major events during the livestream on the day of the crime. | ![image for LivestreamRecording](../unity-ggjj/Assets/Images/Evidence/LivestreamRecording.png) |
 | PlumberInvoice | The invoice from the plumber for repairing the toilets in the north end of the building, dated '2:30PM' today. | ![image for PlumberInvoice](../unity-ggjj/Assets/Images/Evidence/PlumberInvoice.png) |
 | Ross | Animator and self-described sadist. Also really loves milk for some reason. | ![image for Ross](../unity-ggjj/Assets/Images/Profiles/Ross.png) |
@@ -232,6 +236,14 @@
   - ThinkingTalking
 ### Baby
   - Normal
+### Burgie
+  - AirGuitar
+  - Angry
+  - AngryTalking
+  - Lean
+  - Normal
+  - NormalTalking
+  - SideNormal
 ### Dan
   - AirGuitar
   - Angry
@@ -265,6 +277,14 @@
   - ThinkingTalking
   - Warning
   - WarningTalking
+### Laura
+  - AirGuitar
+  - Angry
+  - AngryTalking
+  - Lean
+  - Normal
+  - NormalTalking
+  - SideNormal
 ### Ross
   - Breakdown
   - Damage

--- a/docs/methods/Dialogue.md
+++ b/docs/methods/Dialogue.md
@@ -161,4 +161,7 @@ Examples:
 Makes the next non-action line spoken by a "narrator" actor.
 
 Examples: 
-  - `&NARRATE:Arin`
+  - ```
+    &NARRATE
+        <color=green><align=center>Some Undisclosed Date, 3:30PM<br>10 Minute Power Hour Courthouse</align><color>
+    ```

--- a/unity-ggjj/Assets/Animations/Arin/Arin.controller
+++ b/unity-ggjj/Assets/Animations/Arin/Arin.controller
@@ -229,31 +229,7 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!1101 &-6035610427950064199
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: Talking
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 6250201892440235280}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 0
-  m_HasExitTime: 0
-  m_HasFixedDuration: 0
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 1
+
 --- !u!1102 &-5871059812944580725
 AnimatorState:
   serializedVersion: 6
@@ -1170,33 +1146,7 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!1102 &2949450439157041363
-AnimatorState:
-  serializedVersion: 6
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: PaperSlap 0
-  m_Speed: 1
-  m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: -6035610427950064199}
-  m_StateMachineBehaviours: []
-  m_Position: {x: 50, y: 50, z: 0}
-  m_IKOnFeet: 0
-  m_WriteDefaultValues: 1
-  m_Mirror: 0
-  m_SpeedParameterActive: 0
-  m_MirrorParameterActive: 0
-  m_CycleOffsetParameterActive: 0
-  m_TimeParameterActive: 0
-  m_Motion: {fileID: 7400000, guid: 69baa1120b9f144878703eb270904805, type: 2}
-  m_Tag: 
-  m_SpeedParameter: 
-  m_MirrorParameter: 
-  m_CycleOffsetParameter: 
-  m_TimeParameter: 
+
 --- !u!1101 &3418724191822006455
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -1452,30 +1402,7 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1101 &5658204776667884503
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 2
-    m_ConditionEvent: Talking
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 2949450439157041363}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 0
-  m_HasExitTime: 0
-  m_HasFixedDuration: 0
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
+
   m_CanTransitionToSelf: 1
 --- !u!1101 &5685162434648319745
 AnimatorStateTransition:
@@ -1529,33 +1456,7 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1102 &6250201892440235280
-AnimatorState:
-  serializedVersion: 6
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: PaperSlapTalking 0
-  m_Speed: 1
-  m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: 5658204776667884503}
-  m_StateMachineBehaviours: []
-  m_Position: {x: 50, y: 50, z: 0}
-  m_IKOnFeet: 0
-  m_WriteDefaultValues: 1
-  m_Mirror: 0
-  m_SpeedParameterActive: 0
-  m_MirrorParameterActive: 0
-  m_CycleOffsetParameterActive: 0
-  m_TimeParameterActive: 0
-  m_Motion: {fileID: 7400000, guid: f52381da4f97743abb43d8b96df66c40, type: 2}
-  m_Tag: 
-  m_SpeedParameter: 
-  m_MirrorParameter: 
-  m_CycleOffsetParameter: 
-  m_TimeParameter: 
+
 --- !u!1102 &6510168289250483285
 AnimatorState:
   serializedVersion: 6

--- a/unity-ggjj/Assets/Animations/Burgie.meta
+++ b/unity-ggjj/Assets/Animations/Burgie.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 570ac2eecd517461ebfb31325a285316
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Burgie/AirGuitar.anim
+++ b/unity-ggjj/Assets/Animations/Burgie/AirGuitar.anim
@@ -1,0 +1,159 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AirGuitar
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: -2717325075764081500, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 0.13333334
+      value: {fileID: -1563560005713539998, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 0.33333334
+      value: {fileID: 179716606799038922, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 0.4
+      value: {fileID: -2084893149793539591, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 0.53333336
+      value: {fileID: 6700992557311750711, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 0.8666667
+      value: {fileID: 2941070783967077955, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 1
+      value: {fileID: 4715913143011292566, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 1.3333334
+      value: {fileID: -9071367577438246152, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 1.4666667
+      value: {fileID: 2628388785657136483, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 1.5333333
+      value: {fileID: 6355104138919952737, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 1.6666666
+      value: {fileID: 8654233634233113214, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 2
+      value: {fileID: 5680215912659478875, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 2.1333334
+      value: {fileID: -3315024154330488841, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 2.2666667
+      value: {fileID: -1379978307936831675, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 2.4
+      value: {fileID: -6751391295930718872, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 2.5333333
+      value: {fileID: -5631808631028646290, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 2.6666667
+      value: {fileID: 3958478934395953073, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 2.8
+      value: {fileID: -1604088623285860943, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 2.9333334
+      value: {fileID: 9132252767661879683, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 3.2666667
+      value: {fileID: 5647241043569201154, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 3.3333333
+      value: {fileID: 9000457837936353227, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 3.4666667
+      value: {fileID: 1033108759138759433, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 3.8
+      value: {fileID: -1571668657159789719, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 3.9333334
+      value: {fileID: -6955140910100846438, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 4.133333
+      value: {fileID: -7688693279604622381, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 4.4
+      value: {fileID: 6103005327596628132, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 4.4666667
+      value: {fileID: -7105168888383321786, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 4.6666665
+      value: {fileID: -5557745458458514137, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 4.8
+      value: {fileID: 7137180865968716521, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 15
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: -2717325075764081500, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -1563560005713539998, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 179716606799038922, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -2084893149793539591, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 6700992557311750711, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 2941070783967077955, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 4715913143011292566, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -9071367577438246152, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 2628388785657136483, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 6355104138919952737, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 8654233634233113214, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 5680215912659478875, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -3315024154330488841, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -1379978307936831675, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -6751391295930718872, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -5631808631028646290, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 3958478934395953073, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -1604088623285860943, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 9132252767661879683, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 5647241043569201154, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 9000457837936353227, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 1033108759138759433, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -1571668657159789719, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -6955140910100846438, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -7688693279604622381, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 6103005327596628132, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -7105168888383321786, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -5557745458458514137, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 7137180865968716521, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 4.866667
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events:
+  - time: 4.6666665
+    functionName: OnAnimationComplete
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/unity-ggjj/Assets/Animations/Burgie/AirGuitar.anim.meta
+++ b/unity-ggjj/Assets/Animations/Burgie/AirGuitar.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cf73972c0a836411ba2d249c455bfeea
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Burgie/Angry.anim
+++ b/unity-ggjj/Assets/Animations/Burgie/Angry.anim
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Angry
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 621222158458474870, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - time: 0.1
+      value: {fileID: 6811600293869826227, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - time: 0.2
+      value: {fileID: -6947538433012252695, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - time: 0.3
+      value: {fileID: 2416616704044797164, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - time: 0.4
+      value: {fileID: 3495970692796344209, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - time: 3.5
+      value: {fileID: 3495970692796344209, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 10
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 621222158458474870, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - {fileID: 6811600293869826227, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - {fileID: -6947538433012252695, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - {fileID: 2416616704044797164, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - {fileID: 3495970692796344209, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - {fileID: 3495970692796344209, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 3.6
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/unity-ggjj/Assets/Animations/Burgie/Angry.anim.meta
+++ b/unity-ggjj/Assets/Animations/Burgie/Angry.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 64d1710adbf9144c9aa0760c447fbbbf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Burgie/AngryTalking.anim
+++ b/unity-ggjj/Assets/Animations/Burgie/AngryTalking.anim
@@ -1,0 +1,114 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AngryTalking
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: -8489912797805878322, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.1
+      value: {fileID: -7800345393521115653, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.2
+      value: {fileID: -6461268512302426075, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.3
+      value: {fileID: 6205070021780325143, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.4
+      value: {fileID: -228742272635842205, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.5
+      value: {fileID: 1560169155802941362, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.6
+      value: {fileID: 3607047486209524495, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.7
+      value: {fileID: -7354145723415485363, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.8
+      value: {fileID: -2177863822812396239, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.9
+      value: {fileID: -2173519957937864074, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 1
+      value: {fileID: -2072318499906616748, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 1.1
+      value: {fileID: -3587862790452842393, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 1.2
+      value: {fileID: -6023931864118619868, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 1.3
+      value: {fileID: 3462096614324073040, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 1.4
+      value: {fileID: -2281780587327417612, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 10
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -8489912797805878322, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -7800345393521115653, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -6461268512302426075, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: 6205070021780325143, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -228742272635842205, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: 1560169155802941362, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: 3607047486209524495, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -7354145723415485363, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -2177863822812396239, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -2173519957937864074, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -2072318499906616748, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -3587862790452842393, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -6023931864118619868, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: 3462096614324073040, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -2281780587327417612, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.5
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/unity-ggjj/Assets/Animations/Burgie/AngryTalking.anim.meta
+++ b/unity-ggjj/Assets/Animations/Burgie/AngryTalking.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e91106e4792c43b09151a45cf9d62f8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Burgie/Dan.controller
+++ b/unity-ggjj/Assets/Animations/Burgie/Dan.controller
@@ -1,0 +1,989 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1102 &-8612738293112177739
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Surprised
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-8535098318436644584
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SideNormalTurned
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-8522161573101703210
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SideLaughing
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-8377999366065789969
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3657672195680446274}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-6870397112189981278
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ShockAnimation
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-6468077548091778617
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 0}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-6086217872391765001
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 0}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-6035610427950064199
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 6250201892440235280}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-5899200429878501296
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Angry
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -8377999366065789969}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: b315a1b32e35549deb375802cdf2d04f, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-5695634755458724128
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Fist
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-5381731927017920894
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: CloseUp
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1107 &-3147367188688814144
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: 1512702680851092998}
+    m_Position: {x: 30, y: 130, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 3835138343162926253}
+    m_Position: {x: 300, y: 130, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -2176575121172617828}
+    m_Position: {x: 30, y: 190, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -644305616928634979}
+    m_Position: {x: 300, y: 190, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 3657672195680446274}
+    m_Position: {x: 300, y: 250, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -5899200429878501296}
+    m_Position: {x: 30, y: 250, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -2207009834133596808}
+    m_Position: {x: 30, y: 310, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 1169247718915387039}
+    m_Position: {x: 30, y: 370, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -3084224949528403414}
+    m_Position: {x: 30, y: 430, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -8612738293112177739}
+    m_Position: {x: 30, y: 490, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 3920531941453745242}
+    m_Position: {x: 30, y: 300, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -6870397112189981278}
+    m_Position: {x: 30, y: 610, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 1670679964598260911}
+    m_Position: {x: 30, y: 670, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 2436824214223921613}
+    m_Position: {x: 30, y: 730, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -8522161573101703210}
+    m_Position: {x: 30, y: 790, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -5695634755458724128}
+    m_Position: {x: 30, y: 850, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 7809183526387733554}
+    m_Position: {x: 30, y: 910, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -8535098318436644584}
+    m_Position: {x: 30, y: 970, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 4246769629032412024}
+    m_Position: {x: 30, y: 1030, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -5381731927017920894}
+    m_Position: {x: 30, y: 1090, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 30, z: 0}
+  m_EntryPosition: {x: 50, y: 80, z: 0}
+  m_ExitPosition: {x: 50, y: -20, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: 1512702680851092998}
+--- !u!1102 &-3084224949528403414
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Laughing
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-2207009834133596808
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AirGuitar
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 16f6057490c5944d4861987132ccfcdb, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-2176575121172617828
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Lean
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 3781764093192787129}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: e9ffda90c887e4edf8f5cc104775e8da, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-1140088672769737579
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3657672195680446274}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-644305616928634979
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: LeanTalking
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 8237502283763626179}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Dan
+  serializedVersion: 5
+  m_AnimatorParameters:
+  - m_Name: Talking
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -3147367188688814144}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1102 &1169247718915387039
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Hair
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &1512702680851092998
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Normal
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 5061082664201760760}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 7731a0370c5b0424792523060166d0d6, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &1670679964598260911
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Sad
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &2436824214223921613
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SideNormal
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: cfe354579d22c5c4f8f6ad598604032f, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &2708689020805872983
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 0}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &2949450439157041363
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PaperSlap 0
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -6035610427950064199}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 69baa1120b9f144878703eb270904805, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &3657672195680446274
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AngryTalking
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 4203359840574960413}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: bd79e6a4347b94a3f9aa9620dbe06525, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &3781764093192787129
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -644305616928634979}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &3835138343162926253
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: NormalTalking
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 5685162434648319745}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 41be0090f4c3f4a35a9fa4c7ac810bad, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &3920531941453745242
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Happy
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &4203359840574960413
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -5899200429878501296}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &4246769629032412024
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SideObjection
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &5061082664201760760
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3835138343162926253}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &5658204776667884503
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 2949450439157041363}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &5685162434648319745
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1512702680851092998}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &6250201892440235280
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PaperSlapTalking 0
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 5658204776667884503}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: f52381da4f97743abb43d8b96df66c40, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &7809183526387733554
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SideLean
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &8237502283763626179
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -2176575121172617828}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1

--- a/unity-ggjj/Assets/Animations/Burgie/Dan.controller.meta
+++ b/unity-ggjj/Assets/Animations/Burgie/Dan.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c244a0dd580094e7f8b3312c752da176
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Burgie/Lean.anim
+++ b/unity-ggjj/Assets/Animations/Burgie/Lean.anim
@@ -1,0 +1,92 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Lean
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 1863342976479850380, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - time: 1.6666666
+      value: {fileID: 2945878930083146505, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - time: 1.8333334
+      value: {fileID: 7948017139041608111, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - time: 2
+      value: {fileID: -7025610047208464471, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - time: 2.1666667
+      value: {fileID: 7320825659540279192, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - time: 2.6666667
+      value: {fileID: 2945878930083146505, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - time: 2.8333333
+      value: {fileID: 7948017139041608111, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - time: 3
+      value: {fileID: -7025610047208464471, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - time: 3.1666667
+      value: {fileID: 7320825659540279192, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 6
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 1863342976479850380, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - {fileID: 2945878930083146505, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - {fileID: 7948017139041608111, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - {fileID: -7025610047208464471, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - {fileID: 7320825659540279192, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - {fileID: 2945878930083146505, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - {fileID: 7948017139041608111, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - {fileID: -7025610047208464471, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - {fileID: 7320825659540279192, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 3.3333335
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/unity-ggjj/Assets/Animations/Burgie/Lean.anim.meta
+++ b/unity-ggjj/Assets/Animations/Burgie/Lean.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c06eaa82972734dad9084bc78f112323
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Burgie/Normal.anim
+++ b/unity-ggjj/Assets/Animations/Burgie/Normal.anim
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Normal
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 9095853184155359625, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - time: 0.1
+      value: {fileID: -1829507787872905569, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - time: 0.2
+      value: {fileID: 7838193831867587326, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - time: 0.3
+      value: {fileID: -1491906022276105680, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - time: 0.4
+      value: {fileID: -5428236802488267840, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - time: 4.5
+      value: {fileID: -5428236802488267840, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 10
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 9095853184155359625, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - {fileID: -1829507787872905569, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - {fileID: 7838193831867587326, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - {fileID: -1491906022276105680, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - {fileID: -5428236802488267840, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - {fileID: -5428236802488267840, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 4.6
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/unity-ggjj/Assets/Animations/Burgie/Normal.anim.meta
+++ b/unity-ggjj/Assets/Animations/Burgie/Normal.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a4bd82e8041f46a5bfef21de46ef5c8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Burgie/NormalTalking.anim
+++ b/unity-ggjj/Assets/Animations/Burgie/NormalTalking.anim
@@ -1,0 +1,107 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: NormalTalking
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 46138890513754571, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.1
+      value: {fileID: -661232213070722085, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.2
+      value: {fileID: 7378312704866751538, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.3
+      value: {fileID: -2278997739144042099, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.4
+      value: {fileID: -7776840524345054064, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.5
+      value: {fileID: 9086157907655941450, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.6
+      value: {fileID: 6287082700038233957, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.7
+      value: {fileID: -6276479749388910232, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.8
+      value: {fileID: -4764140993627762133, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.9
+      value: {fileID: -4802966547485692712, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 1
+      value: {fileID: -1249336176646432587, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 1.1
+      value: {fileID: -6988266508294498515, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 1.2
+      value: {fileID: 5417380814132210093, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 1.3
+      value: {fileID: -8167710305643061985, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 10
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 46138890513754571, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -661232213070722085, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: 7378312704866751538, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -2278997739144042099, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -7776840524345054064, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: 9086157907655941450, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: 6287082700038233957, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -6276479749388910232, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -4764140993627762133, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -4802966547485692712, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -1249336176646432587, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -6988266508294498515, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: 5417380814132210093, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -8167710305643061985, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.4
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/unity-ggjj/Assets/Animations/Burgie/NormalTalking.anim.meta
+++ b/unity-ggjj/Assets/Animations/Burgie/NormalTalking.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b78a8478cce5448feac306bcbe2c9036
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Burgie/SideNormal.anim
+++ b/unity-ggjj/Assets/Animations/Burgie/SideNormal.anim
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SideNormal
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: 2411084971427819139, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - time: 0.1
+      value: {fileID: -7155604738691821808, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - time: 0.2
+      value: {fileID: 5618876727781239348, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - time: 0.3
+      value: {fileID: -2199629035893254476, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - time: 0.4
+      value: {fileID: -1919215571950731357, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - time: 2
+      value: {fileID: -1919215571950731357, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 10
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: 2411084971427819139, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - {fileID: -7155604738691821808, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - {fileID: 5618876727781239348, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - {fileID: -2199629035893254476, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - {fileID: -1919215571950731357, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - {fileID: -1919215571950731357, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 2.1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/unity-ggjj/Assets/Animations/Burgie/SideNormal.anim.meta
+++ b/unity-ggjj/Assets/Animations/Burgie/SideNormal.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3da1ffdcc0ee94b5f8e0d58e77c9bf35
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Dan/AngryTalking.anim
+++ b/unity-ggjj/Assets/Animations/Dan/AngryTalking.anim
@@ -7,7 +7,7 @@ AnimationClip:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: AngryTalking
-  serializedVersion: 6
+  serializedVersion: 7
   m_Legacy: 0
   m_Compressed: 0
   m_UseHighQualityCurve: 1
@@ -18,7 +18,8 @@ AnimationClip:
   m_ScaleCurves: []
   m_FloatCurves: []
   m_PPtrCurves:
-  - curve:
+  - serializedVersion: 2
+    curve:
     - time: 0
       value: {fileID: -8489912797805878322, guid: 88836702db7a2dc458044030fec4946c, type: 3}
     - time: 0.1
@@ -53,6 +54,7 @@ AnimationClip:
     path: 
     classID: 212
     script: {fileID: 0}
+    flags: 2
   m_SampleRate: 10
   m_WrapMode: 0
   m_Bounds:
@@ -67,6 +69,8 @@ AnimationClip:
       typeID: 212
       customType: 23
       isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
     pptrCurveMapping:
     - {fileID: -8489912797805878322, guid: 88836702db7a2dc458044030fec4946c, type: 3}
     - {fileID: -7800345393521115653, guid: 88836702db7a2dc458044030fec4946c, type: 3}
@@ -93,7 +97,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 0
+    m_LoopTime: 1
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/unity-ggjj/Assets/Animations/Dan/Dan.controller
+++ b/unity-ggjj/Assets/Animations/Dan/Dan.controller
@@ -312,19 +312,19 @@ AnimatorStateMachine:
     m_Position: {x: 30, y: 250, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -2207009834133596808}
-    m_Position: {x: 30, y: 310, z: 0}
-  - serializedVersion: 1
-    m_State: {fileID: 1169247718915387039}
     m_Position: {x: 30, y: 370, z: 0}
   - serializedVersion: 1
-    m_State: {fileID: -3084224949528403414}
+    m_State: {fileID: 1169247718915387039}
     m_Position: {x: 30, y: 430, z: 0}
   - serializedVersion: 1
-    m_State: {fileID: -8612738293112177739}
+    m_State: {fileID: -3084224949528403414}
     m_Position: {x: 30, y: 490, z: 0}
   - serializedVersion: 1
+    m_State: {fileID: -8612738293112177739}
+    m_Position: {x: 30, y: 550, z: 0}
+  - serializedVersion: 1
     m_State: {fileID: 3920531941453745242}
-    m_Position: {x: 30, y: 300, z: 0}
+    m_Position: {x: 30, y: 310, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -6870397112189981278}
     m_Position: {x: 30, y: 610, z: 0}
@@ -487,7 +487,7 @@ AnimatorState:
   m_MirrorParameterActive: 0
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
-  m_Motion: {fileID: 0}
+  m_Motion: {fileID: 7400000, guid: c67864b1f72c544629b30419b161bb7c, type: 2}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 

--- a/unity-ggjj/Assets/Animations/Dan/LeanTalking.anim
+++ b/unity-ggjj/Assets/Animations/Dan/LeanTalking.anim
@@ -1,0 +1,108 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: LeanTalking
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: 7373696872645602474, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - time: 0.1
+      value: {fileID: -3007967374673735649, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - time: 0.2
+      value: {fileID: -5074354799380432751, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - time: 0.3
+      value: {fileID: -2832942860634587565, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - time: 0.4
+      value: {fileID: -7185705807890651553, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - time: 0.5
+      value: {fileID: -4057184997589775459, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - time: 0.6
+      value: {fileID: -6250671817471417400, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - time: 0.7
+      value: {fileID: -2174744423302483491, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - time: 0.8
+      value: {fileID: -4529787567154779319, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - time: 0.9
+      value: {fileID: 4524318543936856127, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - time: 1
+      value: {fileID: 3481902738889743684, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - time: 1.1
+      value: {fileID: 1849698689995400184, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - time: 1.2
+      value: {fileID: -5751084896163262214, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 10
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: 7373696872645602474, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - {fileID: -3007967374673735649, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - {fileID: -5074354799380432751, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - {fileID: -2832942860634587565, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - {fileID: -7185705807890651553, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - {fileID: -4057184997589775459, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - {fileID: -6250671817471417400, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - {fileID: -2174744423302483491, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - {fileID: -4529787567154779319, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - {fileID: 4524318543936856127, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - {fileID: 3481902738889743684, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - {fileID: 1849698689995400184, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+    - {fileID: -5751084896163262214, guid: 39b73ca47d84a324e9a38c6e7936f8ec, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.3000001
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/unity-ggjj/Assets/Animations/Dan/LeanTalking.anim.meta
+++ b/unity-ggjj/Assets/Animations/Dan/LeanTalking.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c67864b1f72c544629b30419b161bb7c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Laura.meta
+++ b/unity-ggjj/Assets/Animations/Laura.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0389938ec4d8a4c45a3738dfddcb9e93
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Laura/AirGuitar.anim
+++ b/unity-ggjj/Assets/Animations/Laura/AirGuitar.anim
@@ -1,0 +1,159 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AirGuitar
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: -2717325075764081500, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 0.13333334
+      value: {fileID: -1563560005713539998, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 0.33333334
+      value: {fileID: 179716606799038922, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 0.4
+      value: {fileID: -2084893149793539591, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 0.53333336
+      value: {fileID: 6700992557311750711, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 0.8666667
+      value: {fileID: 2941070783967077955, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 1
+      value: {fileID: 4715913143011292566, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 1.3333334
+      value: {fileID: -9071367577438246152, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 1.4666667
+      value: {fileID: 2628388785657136483, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 1.5333333
+      value: {fileID: 6355104138919952737, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 1.6666666
+      value: {fileID: 8654233634233113214, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 2
+      value: {fileID: 5680215912659478875, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 2.1333334
+      value: {fileID: -3315024154330488841, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 2.2666667
+      value: {fileID: -1379978307936831675, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 2.4
+      value: {fileID: -6751391295930718872, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 2.5333333
+      value: {fileID: -5631808631028646290, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 2.6666667
+      value: {fileID: 3958478934395953073, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 2.8
+      value: {fileID: -1604088623285860943, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 2.9333334
+      value: {fileID: 9132252767661879683, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 3.2666667
+      value: {fileID: 5647241043569201154, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 3.3333333
+      value: {fileID: 9000457837936353227, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 3.4666667
+      value: {fileID: 1033108759138759433, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 3.8
+      value: {fileID: -1571668657159789719, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 3.9333334
+      value: {fileID: -6955140910100846438, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 4.133333
+      value: {fileID: -7688693279604622381, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 4.4
+      value: {fileID: 6103005327596628132, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 4.4666667
+      value: {fileID: -7105168888383321786, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 4.6666665
+      value: {fileID: -5557745458458514137, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - time: 4.8
+      value: {fileID: 7137180865968716521, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 15
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: -2717325075764081500, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -1563560005713539998, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 179716606799038922, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -2084893149793539591, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 6700992557311750711, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 2941070783967077955, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 4715913143011292566, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -9071367577438246152, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 2628388785657136483, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 6355104138919952737, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 8654233634233113214, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 5680215912659478875, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -3315024154330488841, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -1379978307936831675, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -6751391295930718872, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -5631808631028646290, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 3958478934395953073, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -1604088623285860943, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 9132252767661879683, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 5647241043569201154, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 9000457837936353227, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 1033108759138759433, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -1571668657159789719, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -6955140910100846438, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -7688693279604622381, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 6103005327596628132, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -7105168888383321786, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: -5557745458458514137, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+    - {fileID: 7137180865968716521, guid: 946f4492058809b4aa701adee451b58b, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 4.866667
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events:
+  - time: 4.6666665
+    functionName: OnAnimationComplete
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/unity-ggjj/Assets/Animations/Laura/AirGuitar.anim.meta
+++ b/unity-ggjj/Assets/Animations/Laura/AirGuitar.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 692be722d2c3348bfa2a9b60dc5d1940
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Laura/Angry.anim
+++ b/unity-ggjj/Assets/Animations/Laura/Angry.anim
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Angry
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 621222158458474870, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - time: 0.1
+      value: {fileID: 6811600293869826227, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - time: 0.2
+      value: {fileID: -6947538433012252695, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - time: 0.3
+      value: {fileID: 2416616704044797164, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - time: 0.4
+      value: {fileID: 3495970692796344209, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - time: 3.5
+      value: {fileID: 3495970692796344209, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 10
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 621222158458474870, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - {fileID: 6811600293869826227, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - {fileID: -6947538433012252695, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - {fileID: 2416616704044797164, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - {fileID: 3495970692796344209, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+    - {fileID: 3495970692796344209, guid: 9a1ef3f064c59e743bdfa46c1e3d4843, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 3.6
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/unity-ggjj/Assets/Animations/Laura/Angry.anim.meta
+++ b/unity-ggjj/Assets/Animations/Laura/Angry.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e729b89a4110344aaa9fd44eee1216ce
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Laura/AngryTalking.anim
+++ b/unity-ggjj/Assets/Animations/Laura/AngryTalking.anim
@@ -1,0 +1,114 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AngryTalking
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: -8489912797805878322, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.1
+      value: {fileID: -7800345393521115653, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.2
+      value: {fileID: -6461268512302426075, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.3
+      value: {fileID: 6205070021780325143, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.4
+      value: {fileID: -228742272635842205, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.5
+      value: {fileID: 1560169155802941362, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.6
+      value: {fileID: 3607047486209524495, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.7
+      value: {fileID: -7354145723415485363, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.8
+      value: {fileID: -2177863822812396239, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 0.9
+      value: {fileID: -2173519957937864074, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 1
+      value: {fileID: -2072318499906616748, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 1.1
+      value: {fileID: -3587862790452842393, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 1.2
+      value: {fileID: -6023931864118619868, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 1.3
+      value: {fileID: 3462096614324073040, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - time: 1.4
+      value: {fileID: -2281780587327417612, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 10
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: -8489912797805878322, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -7800345393521115653, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -6461268512302426075, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: 6205070021780325143, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -228742272635842205, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: 1560169155802941362, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: 3607047486209524495, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -7354145723415485363, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -2177863822812396239, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -2173519957937864074, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -2072318499906616748, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -3587862790452842393, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -6023931864118619868, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: 3462096614324073040, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+    - {fileID: -2281780587327417612, guid: 88836702db7a2dc458044030fec4946c, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.5
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/unity-ggjj/Assets/Animations/Laura/AngryTalking.anim.meta
+++ b/unity-ggjj/Assets/Animations/Laura/AngryTalking.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 936ee8ac62b6b4b66bc90e5e5416da33
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Laura/Dan.controller
+++ b/unity-ggjj/Assets/Animations/Laura/Dan.controller
@@ -1,0 +1,989 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1102 &-8612738293112177739
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Surprised
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-8535098318436644584
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SideNormalTurned
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-8522161573101703210
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SideLaughing
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-8377999366065789969
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3657672195680446274}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-6870397112189981278
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ShockAnimation
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-6468077548091778617
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 0}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-6086217872391765001
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 0}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-6035610427950064199
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 6250201892440235280}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-5899200429878501296
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Angry
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -8377999366065789969}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: b315a1b32e35549deb375802cdf2d04f, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-5695634755458724128
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Fist
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-5381731927017920894
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: CloseUp
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1107 &-3147367188688814144
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: 1512702680851092998}
+    m_Position: {x: 30, y: 130, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 3835138343162926253}
+    m_Position: {x: 300, y: 130, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -2176575121172617828}
+    m_Position: {x: 30, y: 190, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -644305616928634979}
+    m_Position: {x: 300, y: 190, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 3657672195680446274}
+    m_Position: {x: 300, y: 250, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -5899200429878501296}
+    m_Position: {x: 30, y: 250, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -2207009834133596808}
+    m_Position: {x: 30, y: 310, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 1169247718915387039}
+    m_Position: {x: 30, y: 370, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -3084224949528403414}
+    m_Position: {x: 30, y: 430, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -8612738293112177739}
+    m_Position: {x: 30, y: 490, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 3920531941453745242}
+    m_Position: {x: 30, y: 300, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -6870397112189981278}
+    m_Position: {x: 30, y: 610, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 1670679964598260911}
+    m_Position: {x: 30, y: 670, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 2436824214223921613}
+    m_Position: {x: 30, y: 730, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -8522161573101703210}
+    m_Position: {x: 30, y: 790, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -5695634755458724128}
+    m_Position: {x: 30, y: 850, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 7809183526387733554}
+    m_Position: {x: 30, y: 910, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -8535098318436644584}
+    m_Position: {x: 30, y: 970, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 4246769629032412024}
+    m_Position: {x: 30, y: 1030, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -5381731927017920894}
+    m_Position: {x: 30, y: 1090, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 30, z: 0}
+  m_EntryPosition: {x: 50, y: 80, z: 0}
+  m_ExitPosition: {x: 50, y: -20, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: 1512702680851092998}
+--- !u!1102 &-3084224949528403414
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Laughing
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-2207009834133596808
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AirGuitar
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 16f6057490c5944d4861987132ccfcdb, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-2176575121172617828
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Lean
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 3781764093192787129}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: e9ffda90c887e4edf8f5cc104775e8da, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-1140088672769737579
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3657672195680446274}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-644305616928634979
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: LeanTalking
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 8237502283763626179}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Dan
+  serializedVersion: 5
+  m_AnimatorParameters:
+  - m_Name: Talking
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -3147367188688814144}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1102 &1169247718915387039
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Hair
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &1512702680851092998
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Normal
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 5061082664201760760}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 7731a0370c5b0424792523060166d0d6, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &1670679964598260911
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Sad
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &2436824214223921613
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SideNormal
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: cfe354579d22c5c4f8f6ad598604032f, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &2708689020805872983
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 0}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &2949450439157041363
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PaperSlap 0
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -6035610427950064199}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 69baa1120b9f144878703eb270904805, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &3657672195680446274
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AngryTalking
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 4203359840574960413}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: bd79e6a4347b94a3f9aa9620dbe06525, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &3781764093192787129
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -644305616928634979}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &3835138343162926253
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: NormalTalking
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 5685162434648319745}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 41be0090f4c3f4a35a9fa4c7ac810bad, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &3920531941453745242
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Happy
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &4203359840574960413
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -5899200429878501296}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &4246769629032412024
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SideObjection
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &5061082664201760760
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3835138343162926253}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &5658204776667884503
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 2949450439157041363}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &5685162434648319745
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1512702680851092998}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &6250201892440235280
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PaperSlapTalking 0
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 5658204776667884503}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: f52381da4f97743abb43d8b96df66c40, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &7809183526387733554
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SideLean
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions: []
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &8237502283763626179
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Talking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -2176575121172617828}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1

--- a/unity-ggjj/Assets/Animations/Laura/Dan.controller.meta
+++ b/unity-ggjj/Assets/Animations/Laura/Dan.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 780cbf376a3a34ffb901a91e17ffd140
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Laura/Lean.anim
+++ b/unity-ggjj/Assets/Animations/Laura/Lean.anim
@@ -1,0 +1,92 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Lean
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 1863342976479850380, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - time: 1.6666666
+      value: {fileID: 2945878930083146505, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - time: 1.8333334
+      value: {fileID: 7948017139041608111, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - time: 2
+      value: {fileID: -7025610047208464471, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - time: 2.1666667
+      value: {fileID: 7320825659540279192, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - time: 2.6666667
+      value: {fileID: 2945878930083146505, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - time: 2.8333333
+      value: {fileID: 7948017139041608111, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - time: 3
+      value: {fileID: -7025610047208464471, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - time: 3.1666667
+      value: {fileID: 7320825659540279192, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 6
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 1863342976479850380, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - {fileID: 2945878930083146505, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - {fileID: 7948017139041608111, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - {fileID: -7025610047208464471, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - {fileID: 7320825659540279192, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - {fileID: 2945878930083146505, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - {fileID: 7948017139041608111, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - {fileID: -7025610047208464471, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+    - {fileID: 7320825659540279192, guid: c0a0a164d21319049a1a027934b1f21a, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 3.3333335
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/unity-ggjj/Assets/Animations/Laura/Lean.anim.meta
+++ b/unity-ggjj/Assets/Animations/Laura/Lean.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b4df10341d15a4e98a9e7d6547760466
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Laura/Normal.anim
+++ b/unity-ggjj/Assets/Animations/Laura/Normal.anim
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Normal
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 9095853184155359625, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - time: 0.1
+      value: {fileID: -1829507787872905569, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - time: 0.2
+      value: {fileID: 7838193831867587326, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - time: 0.3
+      value: {fileID: -1491906022276105680, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - time: 0.4
+      value: {fileID: -5428236802488267840, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - time: 4.5
+      value: {fileID: -5428236802488267840, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 10
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 9095853184155359625, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - {fileID: -1829507787872905569, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - {fileID: 7838193831867587326, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - {fileID: -1491906022276105680, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - {fileID: -5428236802488267840, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+    - {fileID: -5428236802488267840, guid: 44a8b7dc9ea23e947a628cc07bb63832, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 4.6
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/unity-ggjj/Assets/Animations/Laura/Normal.anim.meta
+++ b/unity-ggjj/Assets/Animations/Laura/Normal.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 86f10a982866b4502a68f8ee25413c81
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Laura/NormalTalking.anim
+++ b/unity-ggjj/Assets/Animations/Laura/NormalTalking.anim
@@ -1,0 +1,107 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: NormalTalking
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 46138890513754571, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.1
+      value: {fileID: -661232213070722085, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.2
+      value: {fileID: 7378312704866751538, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.3
+      value: {fileID: -2278997739144042099, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.4
+      value: {fileID: -7776840524345054064, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.5
+      value: {fileID: 9086157907655941450, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.6
+      value: {fileID: 6287082700038233957, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.7
+      value: {fileID: -6276479749388910232, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.8
+      value: {fileID: -4764140993627762133, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 0.9
+      value: {fileID: -4802966547485692712, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 1
+      value: {fileID: -1249336176646432587, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 1.1
+      value: {fileID: -6988266508294498515, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 1.2
+      value: {fileID: 5417380814132210093, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - time: 1.3
+      value: {fileID: -8167710305643061985, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 10
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 46138890513754571, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -661232213070722085, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: 7378312704866751538, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -2278997739144042099, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -7776840524345054064, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: 9086157907655941450, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: 6287082700038233957, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -6276479749388910232, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -4764140993627762133, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -4802966547485692712, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -1249336176646432587, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -6988266508294498515, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: 5417380814132210093, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+    - {fileID: -8167710305643061985, guid: e4f047e6763fa0f4f991728967dc5400, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.4
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/unity-ggjj/Assets/Animations/Laura/NormalTalking.anim.meta
+++ b/unity-ggjj/Assets/Animations/Laura/NormalTalking.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 02b011546607b4fb7bd5c9ac4e1f85e3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Laura/SideNormal.anim
+++ b/unity-ggjj/Assets/Animations/Laura/SideNormal.anim
@@ -1,0 +1,87 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SideNormal
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - serializedVersion: 2
+    curve:
+    - time: 0
+      value: {fileID: 2411084971427819139, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - time: 0.1
+      value: {fileID: -7155604738691821808, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - time: 0.2
+      value: {fileID: 5618876727781239348, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - time: 0.3
+      value: {fileID: -2199629035893254476, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - time: 0.4
+      value: {fileID: -1919215571950731357, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - time: 2
+      value: {fileID: -1919215571950731357, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+    flags: 2
+  m_SampleRate: 10
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping:
+    - {fileID: 2411084971427819139, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - {fileID: -7155604738691821808, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - {fileID: 5618876727781239348, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - {fileID: -2199629035893254476, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - {fileID: -1919215571950731357, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+    - {fileID: -1919215571950731357, guid: b8cdf44e124ee0f4d87eefe4a098ce85, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 2.1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/unity-ggjj/Assets/Animations/Laura/SideNormal.anim.meta
+++ b/unity-ggjj/Assets/Animations/Laura/SideNormal.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0655222f3f8604c8b90d7ef38b4744ce
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Animations/Ross/Ross.controller
+++ b/unity-ggjj/Assets/Animations/Ross/Ross.controller
@@ -1928,7 +1928,7 @@ AnimatorState:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: SadTalkingNoHelmet
+  m_Name: SadNoHelmetTalking
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:

--- a/unity-ggjj/Assets/Resources/Actors/Burgie.asset
+++ b/unity-ggjj/Assets/Resources/Actors/Burgie.asset
@@ -12,13 +12,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dfc981f29381844a991ebe930492451f, type: 3}
   m_Name: Burgie
   m_EditorClassIdentifier: 
-  <Profile>k__BackingField: {fileID: 21300000, guid: 04b0eedfbca19d84cb4db63538ba6241, type: 3}
+  <Profile>k__BackingField: {fileID: 21300000, guid: ed609b8fe4846d14bad6bb5f2b3677e4, type: 3}
   <DisplayName>k__BackingField: Burgie
   <Age>k__BackingField: 34
   _ageCertainty: 0
   <DisplayColor>k__BackingField: {r: 0.5647059, g: 0.74509805, b: 0.93333334, a: 1}
   <Bio>k__BackingField: Gently floating star of The Grump Cast.
-  <AnimatorController>k__BackingField: {fileID: 9100000, guid: 0c3d8f1233f3a49e9a3f32fab7e316af, type: 2}
+  <AnimatorController>k__BackingField: {fileID: 9100000, guid: 61d75a6dad4224b6f8e9591f88230da3, type: 2}
   <ShoutVariants>k__BackingField:
   - <Item1>k__BackingField: {fileID: 21300000, guid: acb9e7bf00fd28e4bbd6e2ba716692dc, type: 3}
     <Item2>k__BackingField: {fileID: 8300000, guid: 19b48d76ef3cdac4b85155df10b9e673, type: 3}

--- a/unity-ggjj/Assets/Resources/Actors/Burgie.asset
+++ b/unity-ggjj/Assets/Resources/Actors/Burgie.asset
@@ -1,0 +1,29 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dfc981f29381844a991ebe930492451f, type: 3}
+  m_Name: Burgie
+  m_EditorClassIdentifier: 
+  <Profile>k__BackingField: {fileID: 21300000, guid: 04b0eedfbca19d84cb4db63538ba6241, type: 3}
+  <DisplayName>k__BackingField: Burgie
+  <Age>k__BackingField: 34
+  _ageCertainty: 0
+  <DisplayColor>k__BackingField: {r: 0.5647059, g: 0.74509805, b: 0.93333334, a: 1}
+  <Bio>k__BackingField: Gently floating star of The Grump Cast.
+  <AnimatorController>k__BackingField: {fileID: 9100000, guid: 0c3d8f1233f3a49e9a3f32fab7e316af, type: 2}
+  <ShoutVariants>k__BackingField:
+  - <Item1>k__BackingField: {fileID: 21300000, guid: acb9e7bf00fd28e4bbd6e2ba716692dc, type: 3}
+    <Item2>k__BackingField: {fileID: 8300000, guid: 19b48d76ef3cdac4b85155df10b9e673, type: 3}
+  - <Item1>k__BackingField: {fileID: 21300000, guid: d4a8875b0ee18ac4aa74b6921e9b8164, type: 3}
+    <Item2>k__BackingField: {fileID: 8300000, guid: ce1fce4a6857b4e478e0d450dadc7750, type: 3}
+  - <Item1>k__BackingField: {fileID: 21300000, guid: b829cea1a0d6654418a2285a9653dca1, type: 3}
+    <Item2>k__BackingField: {fileID: 8300000, guid: 2d664a5ebfdd03b44b7399265e302fcb, type: 3}
+  <DialogueChirp>k__BackingField: {fileID: 8300000, guid: bec396ecc7b7242499dbad1326715317, type: 3}

--- a/unity-ggjj/Assets/Resources/Actors/Burgie.asset.meta
+++ b/unity-ggjj/Assets/Resources/Actors/Burgie.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7ae185a1139924106b8a6896802e9aef
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Resources/Actors/Laura.asset
+++ b/unity-ggjj/Assets/Resources/Actors/Laura.asset
@@ -12,14 +12,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dfc981f29381844a991ebe930492451f, type: 3}
   m_Name: Laura
   m_EditorClassIdentifier: 
-  <Profile>k__BackingField: {fileID: 21300000, guid: 04b0eedfbca19d84cb4db63538ba6241, type: 3}
+  <Profile>k__BackingField: {fileID: 21300000, guid: ed609b8fe4846d14bad6bb5f2b3677e4, type: 3}
   <DisplayName>k__BackingField: Laura
   <Age>k__BackingField: 35
   _ageCertainty: 0
   <DisplayColor>k__BackingField: {r: 0.38431373, g: 0.25418067, b: 0.7058824, a: 1}
   <Bio>k__BackingField: Divorced. Lacking 3 toes. Not to be confused with Rachel,
     working for Fart Modeing.
-  <AnimatorController>k__BackingField: {fileID: 9100000, guid: 0c3d8f1233f3a49e9a3f32fab7e316af, type: 2}
+  <AnimatorController>k__BackingField: {fileID: 9100000, guid: 61d75a6dad4224b6f8e9591f88230da3, type: 2}
   <ShoutVariants>k__BackingField:
   - <Item1>k__BackingField: {fileID: 21300000, guid: acb9e7bf00fd28e4bbd6e2ba716692dc, type: 3}
     <Item2>k__BackingField: {fileID: 8300000, guid: 19b48d76ef3cdac4b85155df10b9e673, type: 3}

--- a/unity-ggjj/Assets/Resources/Actors/Laura.asset
+++ b/unity-ggjj/Assets/Resources/Actors/Laura.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dfc981f29381844a991ebe930492451f, type: 3}
+  m_Name: Laura
+  m_EditorClassIdentifier: 
+  <Profile>k__BackingField: {fileID: 21300000, guid: 04b0eedfbca19d84cb4db63538ba6241, type: 3}
+  <DisplayName>k__BackingField: Laura
+  <Age>k__BackingField: 35
+  _ageCertainty: 0
+  <DisplayColor>k__BackingField: {r: 0.38431373, g: 0.25418067, b: 0.7058824, a: 1}
+  <Bio>k__BackingField: Divorced. Lacking 3 toes. Not to be confused with Rachel,
+    working for Fart Modeing.
+  <AnimatorController>k__BackingField: {fileID: 9100000, guid: 0c3d8f1233f3a49e9a3f32fab7e316af, type: 2}
+  <ShoutVariants>k__BackingField:
+  - <Item1>k__BackingField: {fileID: 21300000, guid: acb9e7bf00fd28e4bbd6e2ba716692dc, type: 3}
+    <Item2>k__BackingField: {fileID: 8300000, guid: 19b48d76ef3cdac4b85155df10b9e673, type: 3}
+  - <Item1>k__BackingField: {fileID: 21300000, guid: d4a8875b0ee18ac4aa74b6921e9b8164, type: 3}
+    <Item2>k__BackingField: {fileID: 8300000, guid: ce1fce4a6857b4e478e0d450dadc7750, type: 3}
+  - <Item1>k__BackingField: {fileID: 21300000, guid: b829cea1a0d6654418a2285a9653dca1, type: 3}
+    <Item2>k__BackingField: {fileID: 8300000, guid: 2d664a5ebfdd03b44b7399265e302fcb, type: 3}
+  <DialogueChirp>k__BackingField: {fileID: 8300000, guid: 5e39ad496f303fd46a0fe47c66dbaa1b, type: 3}

--- a/unity-ggjj/Assets/Resources/Actors/Laura.asset.meta
+++ b/unity-ggjj/Assets/Resources/Actors/Laura.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6a309ec5e15fc451ebcc349615138ea9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Scripts/TextDecoder/ActionDecoder.cs
+++ b/unity-ggjj/Assets/Scripts/TextDecoder/ActionDecoder.cs
@@ -472,7 +472,8 @@ public class ActionDecoder : ActionDecoderBase
     }
 
     /// <summary>Makes the next non-action line spoken by a "narrator" actor.</summary>
-    /// <example>&amp;NARRATE:Arin</example>
+    /// <example>&amp;NARRATE
+    /// &#160;&#160;&#160;&#160;&lt;color=green&gt;&lt;align=center&gt;Some Undisclosed Date, 3:30PM&lt;br&gt;10 Minute Power Hour Courthouse&lt;/align&gt;&lt;color&gt;</example>
     /// <category>Dialogue</category>
     private void NARRATE()
     {


### PR DESCRIPTION
## Summary
Recommend checking out each commit individually. Resolves a few things:
- Adds colored nameplates for Burgie and Laura (51fc67d) while relying on Dan's animations to not break the docs generator (583c027) to get the demo `.ink` script closer to the Google Docs version
- `&NARRATE` had an incorrect example with a parameter that wasn't required (6045a66)
- Dan stopped talking when using the "Angry talk" sprite even if there was text left; it now correctly loops until all text is displayed (9bf62c9)
- My IDE kept adding files, so I've added it to the `.gitignore` as no one else is using Rider (5527251)
- Ross' animation `SadNoHelmetTalking` was incorrectly named `SadTalkingNoHelmet` in the documentation (7e3d55b)
- Added pudding haired leaning+talking sprite for Dan to prevent an empty scene until the new sprites are ready (e679c68)

## Testing instructions
- Verify the Burgie and Laura nameplates show up when used
- Look at the newly generated docs for `&NARRATE`
- Make Dan speak a long line while using the `Angry` pose and verify that mouth movements only stop after all text is displayed
- Make Dan speak and lean and verify that an animation is shown
## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[x]` Has associated resource: 
  - closes #444