### PR TITLE
Enhanced animation pose documentation generation

### DIFF
--- a/docs/constants.md
+++ b/docs/constants.md
@@ -204,131 +204,71 @@
 
 ## ActorPoseAssetName
 ### Arin
-  - Annoyed
-  - AnnoyedTalking
-  - CloseUp
-  - CloseUpTalking
-  - Confident
-  - ConfidentTalking
-  - DeskSlam
-  - DeskSlamAnimation
-  - DeskSlamTalking
-  - Embarrassed
-  - EmbarrassedTalking
+  - Annoyed (🗣️)
+  - CloseUp (🗣️)
+  - Confident (🗣️)
+  - DeskSlamAnimation (🗣️, 🎦)
+  - Embarrassed (🗣️)
   - HelmetHit
   - Nodding
-  - Normal
-  - NormalTalking
-  - Objection
-  - PaperSlap
-  - PaperSlapTalking
-  - Point
-  - PointTalking
+  - Normal (🗣️)
+  - Objection (🗣️, 🎦)
+  - PaperSlap (🗣️)
   - ShakingHead
-  - Shock
   - ShockAnimation
-  - Sweaty
-  - SweatyBlinking
-  - SweatyBlinkingTalking
-  - SweatyTalking
-  - Thinking
+  - Sweaty (🗣️)
+  - SweatyBlinking (🗣️)
+  - Thinking (🗣️)
   - ThinkingBlinking
-  - ThinkingTalking
 ### Baby
   - Normal
 ### Burgie
-  - AirGuitar
-  - Angry
-  - AngryTalking
-  - Lean
-  - Normal
-  - NormalTalking
-  - SideNormal
 ### Dan
   - AirGuitar
-  - Angry
-  - AngryTalking
-  - Lean
-  - LeanTalking
-  - Normal
-  - NormalTalking
+  - Angry (🗣️)
+  - Lean (🗣️)
+  - Normal (🗣️)
   - SideNormal
 ### Jory
-  - Nervous
-  - NervousTalking
-  - Normal
-  - NormalTalking
-  - Sweaty
-  - SweatyTalking
-  - Thinking
-  - ThinkingTalking
-  - ThumbsUp
-  - ThumbsUpTalking
+  - Nervous (🗣️)
+  - Normal (🗣️)
+  - Sweaty (🗣️)
+  - Thinking (🗣️)
+  - ThumbsUp (🗣️)
   - WideShot
 ### JudgeBrent
-  - Angry
-  - AngryTalking
+  - Angry (🗣️)
   - HeadShake
   - Nodding
-  - Normal
-  - NormalTalking
-  - Surprised
-  - SurprisedTalking
-  - Thinking
-  - ThinkingTalking
-  - Warning
-  - WarningTalking
+  - Normal (🗣️)
+  - Surprised (🗣️)
+  - Thinking (🗣️)
+  - Warning (🗣️)
 ### Laura
-  - AirGuitar
-  - Angry
-  - AngryTalking
-  - Lean
-  - Normal
-  - NormalTalking
-  - SideNormal
 ### Ross
   - Breakdown
   - Damage
   - DamageNoHelmet
-  - Glaring
-  - Glaring (uncropped)
-  - GlaringNoHelmet
-  - GlaringNoHelmet (uncropped)
-  - GlaringTalking
-  - GlaringTalking (uncropped)
-  - GlaringTalkingNoHelmet
-  - GlaringTalkingNoHelmet (uncropped)
+  - Glaring (🗣️)
+  - GlaringNoHelmet (🗣️)
   - HelmetThrow
-  - MadMilk
-  - MadmilkTalking
-  - Normal
-  - NormalNoHelmet
-  - NormalTalking
-  - NormalTalkingNoHelmet
-  - Sad
-  - SadNoHelmet
-  - SadNoHelmetTalking
-  - SadTalking
-  - Sweaty
-  - SweatyNoHelmet
-  - SweatyNoHelmetTalking
-  - SweatyTalking
+  - MadMilk (🗣️)
+  - Normal (🗣️)
+  - NormalNoHelmet (🗣️)
+  - Sad (🗣️)
+  - SadNoHelmet (🗣️)
+  - Sweaty (🗣️)
+  - SweatyNoHelmet (🗣️)
   - WideShot
 ### TutorialBoy
-  - Angry
-  - AngryTalking
-  - AngryTalkingAlt
-  - Confident
-  - ConfidentTalking
+  - Angry (🗣️)
+  - AngryAlt (🗣️)
+  - Confident (🗣️)
   - HeadSlam
-  - Normal
-  - NormalTalking
-  - NormalTalkingAlt
-  - Objection
-  - Point
-  - PointTalking
-  - PointTalkingAlt
-  - Sweaty
-  - SweatyTalking
+  - Normal (🗣️)
+  - NormalAlt (🗣️)
+  - Objection (🗣️, 🎦)
+  - ObjectionAlt (🗣️, 🎦)
+  - Sweaty (🗣️)
   - Yeeta
 

--- a/docs_generator/AnimationControllerParser.cs
+++ b/docs_generator/AnimationControllerParser.cs
@@ -17,15 +17,16 @@ public static class AnimationControllerParser
         public override string ToString()
         {
             var attributes = new List<string>();
-            if (HasTalking)
+            if (!HasTalking)
             {
-                attributes.Add("🗣️");
+                return $"{EntryPoint}";
             }
+            attributes.Add("🗣️");
             if (HasIntro)
             {
                 attributes.Add("🎦");
             }
-            
+
             return $"{EntryPoint} ({string.Join(", ", attributes)})";
         }
     }

--- a/docs_generator/AnimationControllerParser.cs
+++ b/docs_generator/AnimationControllerParser.cs
@@ -1,0 +1,230 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using YamlDotNet.Serialization;
+
+namespace Scanner;
+
+public static class AnimationControllerParser
+{
+    public record Info
+    {
+        public string EntryPoint { get; init; }
+        public bool HasIntro { get; init; }
+        public bool HasTalking { get; init; }
+        
+        public override string ToString()
+        {
+            var attributes = new List<string>();
+            if (HasTalking)
+            {
+                attributes.Add("🗣️");
+            }
+            if (HasIntro)
+            {
+                attributes.Add("🎦");
+            }
+            
+            return $"{EntryPoint} ({string.Join(", ", attributes)})";
+        }
+    }
+
+    private static Info ToInfo(IEnumerable<string> states)
+    {
+        var stateList = states.ToList();
+        return stateList.Count switch
+        {
+            1 => new Info()
+            {
+                EntryPoint = stateList.First(), 
+                HasIntro = true, HasTalking = false
+            },
+            2 => new Info()
+            {
+                EntryPoint = stateList.First(), 
+                HasIntro = !stateList.Any(state => state.Contains("Talking")), 
+                HasTalking = stateList.Any(state => state.Contains("Talking"))
+            },
+            3 => new Info()
+            {
+                EntryPoint = stateList.First(),
+                HasIntro = true,
+                HasTalking = stateList.Any(state => state.Contains("Talking"))
+            },
+            _ => throw new NotSupportedException("Only 1, 2 or 3 states are supported")
+        };
+    }
+    
+    #region Unity types
+    // these types are used to deserialize the YAML file and cause warnings
+    // ReSharper disable MemberCanBePrivate.Global
+    // ReSharper disable InconsistentNaming
+    // ReSharper disable ClassNeverInstantiated.Global
+    // ReSharper disable UnusedAutoPropertyAccessor.Global
+    public record UnityUnused
+    {
+    }
+    public record UnityAnimatorState
+    {
+        public record Content
+        {
+            public record Motion
+            {
+                public string? guid { get; init; }
+            }
+            public string m_Name { get; init; }
+            public Motion m_Motion { get; init; }
+            public List<FileReference> m_Transitions { get; init; }
+        }
+        public Content AnimatorState { get; init; }
+    }
+
+    public record UnityAnimatorStateTransition
+    {
+        public record Content
+        {
+            public FileReference m_DstState { get; init; }
+        }
+        public Content AnimatorStateTransition { get; init; }
+    }
+
+    public record FileReference
+    {
+        public string fileID { get; init; }
+    }
+    // ReSharper restore UnusedAutoPropertyAccessor.Global
+    // ReSharper restore ClassNeverInstantiated.Global
+    // ReSharper restore InconsistentNaming
+    // ReSharper restore MemberCanBePrivate.Global
+    #endregion
+
+    public static List<PathItem> ConvertToMarkdown(string absolutePathToAssetsDirectory, Dictionary<string, string> pathsByGUID, string relativeFileName)
+    {
+        var yamlContent = File.ReadAllText(Path.Join(absolutePathToAssetsDirectory, relativeFileName));
+        
+        // read the .controller YAML syntax by mapping YAML fields to C# records depending on the tag
+        var deserializer = new DeserializerBuilder()
+            .IgnoreUnmatchedProperties()
+            .WithTagMapping("tag:unity3d.com,2011:1102", typeof(UnityAnimatorState))
+            .WithTagMapping("tag:unity3d.com,2011:1101", typeof(UnityAnimatorStateTransition))
+            .WithTagMapping("tag:unity3d.com,2011:1107", typeof(UnityUnused)) // AnimatorStateMachine
+            .WithTagMapping("tag:unity3d.com,2011:91", typeof(UnityUnused)) // AnimatorController
+            .WithTagMapping("tag:unity3d.com,2011:206", typeof(UnityUnused)) // BlendTree
+            .WithTagMapping("tag:unity3d.com,2011:114", typeof(UnityUnused)) // MonoBehaviour
+            .Build();
+        
+        // Unity's variant of YAML isn't "proper" YAML
+        // https://github.com/aaubry/YamlDotNet/issues/140#issuecomment-206927072
+        // to work around this, split the file by…
+        var items = yamlContent.Split("---");
+        // treat the first part as a header…
+        var header = items[0];
+        var list = items[1..]
+            // that gets prepended to every item
+            .Select(item => header + "---" + item)
+            .ToDictionary(
+                // fetch the ID of each item by taking the value after `&` in the third line
+                item => item.Split("\n")[2].Split("&")[1],
+                // and parse the resulting YAML into a dynamic object based on the TagMapping from above
+                item => deserializer.Deserialize<dynamic>(item)
+            );
+            
+        // we're only interested in the states and transitions, that represent the controller graph
+        var animatorStates = list
+            .Where(pair => pair.Value is UnityAnimatorState)
+            .ToDictionary(pair => pair.Key, pair => pair.Value as UnityAnimatorState)
+            .Where(pair =>
+            {
+                if (pair.Value?.AnimatorState.m_Motion.guid == null)
+                {
+                    return false;
+                }
+                return pathsByGUID.ContainsKey(pair.Value.AnimatorState.m_Motion.guid);
+            })
+            .ToDictionary(pair => pair.Key, pair => pair.Value);
+        var animatorStateTransitions = list
+            .Where(pair => pair.Value is UnityAnimatorStateTransition)
+            .ToDictionary(pair => pair.Key, pair => pair.Value as UnityAnimatorStateTransition);
+        
+        // Graph traversal methods based on states representing nodes and transitions representing edges
+        #region Graph traversal
+        List<string> FindAllStates(string startKey)
+        {
+            var visited = new HashSet<string>();
+            return FindAllStatesRecursive(startKey, visited);
+        }
+
+        List<string> FindAllStatesRecursive(string startKey, HashSet<string> visited)
+        {
+            List<string> states = [];
+            if (visited.Contains(startKey))
+            {
+                return states;
+            }
+            states.Add(startKey);
+            visited.Add(startKey);
+
+            var transitions = animatorStates[startKey].AnimatorState.m_Transitions;
+            foreach (var transition in transitions)
+            {
+                var key = transition.fileID;
+                key = animatorStateTransitions[key].AnimatorStateTransition.m_DstState.fileID;
+                if (!visited.Contains(key))
+                {
+                    states.AddRange(FindAllStatesRecursive(key, visited));
+                }
+            }
+            return states;
+        }
+        #endregion
+        
+        // documentation should only contain states that we consider an "entry point" 
+        //
+        // nodes can be of three types
+        //   - a talking state
+        //   - a non-talking state
+        //   - an intro state
+        //
+        // a state is an entry points if it is…
+        //  - a stand-alone state
+        //  - OR
+        //  -   not a talking state AND
+        //  -   not transitioned into by another entry point
+        
+        // find all states that are         
+        var entryPoints = animatorStates
+            // not a talking state
+            .Where(pair => !pair.Value.AnimatorState.m_Name.Contains("Talking")) // AND
+            // have less than 2 transitions into them
+            .Where(pair => animatorStateTransitions.Count(entry => entry.Value.AnimatorStateTransition.m_DstState.fileID == pair.Key) < 2
+            ).ToList();
+        
+        var transitionsOfEntryPoints = entryPoints
+            .SelectMany(entryPoint =>
+                entryPoint.Value.AnimatorState.m_Transitions.Select(transition=> animatorStateTransitions[transition.fileID].AnimatorStateTransition.m_DstState.fileID)
+            );
+
+        var info = entryPoints
+            // also ignore states that are only transitioned into by other entry points
+            .Where(entryPoint => !transitionsOfEntryPoints.Contains(entryPoint.Key))
+            // sort them alphabetically
+            .OrderBy(a=>a.Value.AnimatorState.m_Name)
+            // then traverse the graph until we find a duplicate
+            .Select(entryPoint =>
+                FindAllStates(entryPoint.Key).Select(id=>animatorStates[id].AnimatorState.m_Name).ToList()
+            )
+            // then summarize the info for the documentation
+            .Select(ToInfo)
+            .ToList();
+
+        return info.Select(line =>
+            new PathItem()
+            {
+                Item = line.ToString()
+            }
+        ).ToList();
+
+    }
+}

--- a/docs_generator/AnimationControllerParser.cs
+++ b/docs_generator/AnimationControllerParser.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -9,7 +8,7 @@ namespace Scanner;
 
 public static class AnimationControllerParser
 {
-    public record Info
+    private record Info
     {
         public string EntryPoint { get; init; }
         public bool HasIntro { get; init; }
@@ -63,16 +62,15 @@ public static class AnimationControllerParser
     // ReSharper disable InconsistentNaming
     // ReSharper disable ClassNeverInstantiated.Global
     // ReSharper disable UnusedAutoPropertyAccessor.Global
-    public record UnityUnused
-    {
-    }
+    // ReSharper disable CollectionNeverUpdated.Global
+    public record UnityUnused;
     public record UnityAnimatorState
     {
         public record Content
         {
             public record Motion
             {
-                public string? guid { get; init; }
+                public string guid { get; init; }
             }
             public string m_Name { get; init; }
             public Motion m_Motion { get; init; }
@@ -108,13 +106,14 @@ public static class AnimationControllerParser
     {
         public string fileID { get; init; }
     }
+    // ReSharper restore CollectionNeverUpdated.Global
     // ReSharper restore UnusedAutoPropertyAccessor.Global
     // ReSharper restore ClassNeverInstantiated.Global
     // ReSharper restore InconsistentNaming
     // ReSharper restore MemberCanBePrivate.Global
     #endregion
 
-    public static List<PathItem> ConvertToMarkdown(string absolutePathToAssetsDirectory, Dictionary<string, string> pathsByGUID, string relativeFileName)
+    public static List<PathItem> ConvertToPathItem(string absolutePathToAssetsDirectory, Dictionary<string, string> pathsByGUID, string relativeFileName)
     {
         var yamlContent = File.ReadAllText(Path.Join(absolutePathToAssetsDirectory, relativeFileName));
         
@@ -124,6 +123,7 @@ public static class AnimationControllerParser
             .WithTagMapping("tag:unity3d.com,2011:1102", typeof(UnityAnimatorState))
             .WithTagMapping("tag:unity3d.com,2011:1101", typeof(UnityAnimatorStateTransition))
             .WithTagMapping("tag:unity3d.com,2011:1107", typeof(UnityAnimatorStateMachine)) // AnimatorStateMachine
+            // not binding all used tags results in exceptions; silence them by mapping them to a dummy type
             .WithTagMapping("tag:unity3d.com,2011:91", typeof(UnityUnused)) // AnimatorController
             .WithTagMapping("tag:unity3d.com,2011:206", typeof(UnityUnused)) // BlendTree
             .WithTagMapping("tag:unity3d.com,2011:114", typeof(UnityUnused)) // MonoBehaviour

--- a/docs_generator/XMLDocParser.cs
+++ b/docs_generator/XMLDocParser.cs
@@ -19,16 +19,16 @@ public class PathItem
     public bool IsComplex => !string.IsNullOrEmpty(Description) || !string.IsNullOrEmpty(RelativeIconPath);
     public IEnumerable<PathItem> Children { get; init; }
 
-    private static readonly Dictionary<string, Func<string, Dictionary<string, string>, string, List<PathItem>>> filetypeOverrides = new()
+    private static readonly Dictionary<string, Func<string, Dictionary<string, string>, string, List<PathItem>>> FiletypeOverrides = new()
     {
-        { "controller", AnimationControllerParser.ConvertToMarkdown },
-        { "asset", AssetParser.ConvertToMarkdown }
+        { "controller", AnimationControllerParser.ConvertToPathItem },
+        { "asset", AssetParser.ConvertToPathItem }
     };
     
     public static List<PathItem> Generate(string absolutePathToAssetsDirectory, Dictionary<string, string> pathsByGUID, string relativeFileName)
     {
         var fileEnding = relativeFileName.Split(".").Last();
-        if (filetypeOverrides.TryGetValue(fileEnding, out var creationMethod))
+        if (FiletypeOverrides.TryGetValue(fileEnding, out var creationMethod))
         {
             return creationMethod(absolutePathToAssetsDirectory, pathsByGUID, relativeFileName);
         }
@@ -39,7 +39,7 @@ public class PathItem
 
 internal static class AssetParser
 {
-    public static List<PathItem> ConvertToMarkdown(string absolutePathToAssetsDirectory, Dictionary<string, string> pathsByGUID, string relativeFileName)
+    public static List<PathItem> ConvertToPathItem(string absolutePathToAssetsDirectory, Dictionary<string, string> pathsByGUID, string relativeFileName)
     {
         var contents = File.ReadAllText(Path.Join(absolutePathToAssetsDirectory, relativeFileName));
         if (contents[0] == '%')

--- a/unity-ggjj/Assets/Scripts/TextDecoder/ActionDecoder.cs
+++ b/unity-ggjj/Assets/Scripts/TextDecoder/ActionDecoder.cs
@@ -482,7 +482,7 @@ public class ActionDecoder : ActionDecoderBase
     }
 
     /// <summary>Makes the currently shown actor switch to target pose. Plays any animation associated with target pose / emotion, but doesn't wait until it is finished before continuing.</summary>
-    /// <param name="poseName" validFiles="Assets/Animations/{ActorAssetName}/*.anim">Poses defined per Actor</param>
+    /// <param name="poseName" validFiles="Assets/Animations/{ActorAssetName}/{ActorAssetName}.controller">Poses defined per Actor</param>
     /// <param name="optional_targetActor" validFiles="Assets/Resources/Actors/*.asset">(optional) Name of the actor</param>
     /// <example>&amp;SET_POSE:Normal</example>
     /// <category>Actor</category>
@@ -500,7 +500,7 @@ public class ActionDecoder : ActionDecoderBase
     }
 
     /// <summary>Makes the currently shown actor perform target emotion (fancy word animation on an actor). Practically does the same as SET_POSE, but waits for the emotion to complete. Doesn't work on all poses, possible ones are flagged.</summary>
-    /// <param name="poseName" validFiles="Assets/Animations/{ActorAssetName}/*.anim">Poses defined per Actor</param>
+    /// <param name="poseName" validFiles="Assets/Animations/{ActorAssetName}/{ActorAssetName}.controller">Poses defined per Actor</param>
     /// <param name="optional_targetActor" validFiles="Assets/Resources/Actors/*.asset">(optional) Name of the actor</param>
     /// <example>&amp;PLAY_EMOTION:Nodding</example>
     /// <category>Actor</category>


### PR DESCRIPTION
## Before/after screenshots and/or animated gif
Closes #446: Adds indicators denoting which animations have a talk-state (🗣️) and intro movements (🎦).
![image](https://github.com/user-attachments/assets/e0b2cdc1-52f7-4dc0-b7e1-6cef869e92a9)


## Summary
This PR might be a bit difficult to review; I'd recommend split- (rather than inline-) diff viewing the entire PR all at once and I'll add a bit of context:
The documentation generator is fairly simple:
It scans xmldoc comments of the `ActionDecoder`, that define [which files are valid for action lines](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/blob/012f71bdd25b481283eecaec2d112abfe92d988d/unity-ggjj/Assets/Scripts/TextDecoder/ActionDecoder.cs#L485)…
```xml
<param name="poseName" validFiles="Assets/Animations/{ActorAssetName}/*.anim">Poses defined per Actor</param>
```
…and creates a list in the documentation (left side of the screenshot).
The only exception were `.asset` files. Actors and Evidence were parsed, then rendered in a table: 
<img width="936" alt="image" src="https://github.com/user-attachments/assets/0dc8083d-bb67-4e35-8520-f5fad7e14b8c">

I've extended the generator, to not just handle `.asset` files differently, but [any type we want](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/commit/60f6a10f678eea20a5faa9f243c281abd8a85c60#diff-5441bbe444820a4b04b7588e84bd2251f13a002fda8f8b0408057642c6e4f398R77-R81).

From now on, [if we have a special handler we use it, otherwise just render the file name.](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/commit/60f6a10f678eea20a5faa9f243c281abd8a85c60#diff-5441bbe444820a4b04b7588e84bd2251f13a002fda8f8b0408057642c6e4f398R86-R91)

List or table entries are represented [as `PathItem`s in code](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/commit/60f6a10f678eea20a5faa9f243c281abd8a85c60#diff-5441bbe444820a4b04b7588e84bd2251f13a002fda8f8b0408057642c6e4f398R71-R75). If they're complex we render a table, if not we render a list.

I've changed poses [to use the `.controller` instead](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/commit/60f6a10f678eea20a5faa9f243c281abd8a85c60#diff-fecb3d4574eb7680793d0780876ca5444afb58a779bb9942cc2e6d95feaeba59R485-R503) which allows offering more context about animations and added a special handler to the generator.

The new handler parses animation controllers (any Unity data is just YAML).  
I've made an effort to [document the logic](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/commit/60f6a10f678eea20a5faa9f243c281abd8a85c60#diff-192f0ed1dfce1bd00bad8d4192bf358362a30a0308ff9a1996161641855c5627), feel free to give it a read.
The short form:
1. Find all states we deem "entrypoints" (highlighted in this screenshot):
   <img width="514" alt="image" src="https://github.com/user-attachments/assets/ceafe0e5-8736-4821-90c3-b5bbd5e2100b">
2. Check if they have a talking variants and/or an intro animation
3. Render that in the docs

## Testing instructions
Verify, that [the automatically generated docs](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/blob/1bdd90d84a332e8b3b6fd99952cbadf0daed253b/docs/constants.md#actorposeassetname) show all currently available entry points for all actors, and whether or not they have talking variants and/or intros.

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[x]` Has associated resource: 
  - closes #446
