### PR TITLE
Resolves GitHub Pre-Release issues

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -87,6 +87,7 @@ jobs:
     uses: ./.github/workflows/build_game.yml
     with:
       unityPlatform: ${{ matrix.targetPlatform.unityPlatform }}
+      versionNumber: ${{ needs.setVersionNumber.outputs.version_number }}
       outputName: ${{ matrix.targetPlatform.outputName }}
     secrets: inherit
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -167,7 +167,7 @@ jobs:
   # GitHub Releases
   createGitHubRelease:
     name: Create GitHub Release
-    needs: [setVersionNumber, checkIfTagExists, unityBuild]
+    needs: [setVersionNumber, checkIfTagExists, unityBuild, runUnityTests]
     if: (github.event.inputs.createRelease == 'true' || (github.ref == 'refs/heads/develop' && github.event_name == 'push'))
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Use run id
         id: setVersionNumber_job
         run: |
-            echo "version_number=$(date +'%Y.%m.%d')-$(echo $GITHUB_RUN_ID)" >> $GITHUB_OUTPUT
+            echo "version_number=$(date +'%Y.%m.%d')-$(echo $GITHUB_RUN_NUMBER)" >> $GITHUB_OUTPUT
             if [[ '${{ github.event.inputs.createRelease }}' == 'true' ]]; then
               echo "version_name="Release v${{ needs.setVersionNumber.outputs.version_number }}" >> $GITHUB_OUTPUT
             else

--- a/.github/workflows/build_game.yml
+++ b/.github/workflows/build_game.yml
@@ -7,6 +7,10 @@ on:
         description: 'Target platform of the built artifact'
         type: string
         required: true
+      versionNumber:
+        description: 'Pre-generated version number'
+        type: string
+        required: true
       outputName:
         description: 'Name of the artifact generated'
         type: string
@@ -69,5 +73,5 @@ jobs:
       - name: Upload '${{ inputs.outputName }}' artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.outputName }}-v${{ github.run_number }}
+          name: ${{ inputs.outputName }}-v${{ inputs.versionNumber }}
           path: build/${{ inputs.unityPlatform }}


### PR DESCRIPTION
## Summary
#476 introduced the ability to automatically generate Pre-Releases on GitHub, which was untestable and (of course 🫠) failed. This should address the issues and changes one tiny detail. I've split them up into separate commits, to make them easy to follow:

## Before/after screenshots and/or animated gif
- 6957c7f0f117a5150193bc3ad0f5fa24f597e4f8 fixes what broke the Pre-Release logic in #476: The steps that build and upload the artifacts to GitHub are different from the ones creating the GitHub Release. **The upload** still used the **old** format of version numbers, while the **download** used the **new** format. This commit updates the download to use the new format.
- 943f14abb83f4a638e64446ced6d3d9fda729a50: Previously the Pre-Release didn't wait for successful test completion, which it does now
- 3f7addcad8975979113186a586fc4f872c886861: Each GitHub Action run has a globally unique ID (e.g. 10786619055) and a workflow-specific run number (e.g. 355). As only one workflow can creates GitHub Releases, we have no need for globally unique numbers and I have opted to use the smaller number:
  - Old: `macOS-v2024.09.10-10786619055`
  - New: `macOS-v2024.09.10-355`

## Testing instructions
See [#476](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/pull/476#:~:text=Testing%20instructions)

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[x]` Has associated resource: 
  closes #467
