### PR TITLE
Prerelease descriptions contain all commits since last prerelease

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -167,7 +167,12 @@ jobs:
     needs: [setVersionNumber, checkIfTagExists, unityBuild, runUnityTests]
     if: (github.event.inputs.createRelease == 'true' || (github.ref == 'refs/heads/develop' && github.event_name == 'push'))
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download macOS
         uses: actions/download-artifact@v4
         with:
@@ -205,6 +210,23 @@ jobs:
       - name: Zip WebGL
         run: zip -r "${{ github.workspace }}/build/WebGL-v${{ needs.setVersionNumber.outputs.version_number }}.zip"       "build/WebGL-v${{ needs.setVersionNumber.outputs.version_number }}"
 
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Build release notes generator
+        working-directory: ./release_notes_generator/ReleaseNotesGenerator
+        run: dotnet build ReleaseNotesGenerator.csproj
+
+      - name: Generate release notes
+        working-directory: ./
+        run: ./release_notes_generator/ReleaseNotesGenerator/bin/Debug/net8.0/ReleaseNotesGenerator
+
+      - name: Print generated release notes
+        working-directory: ./
+        run: cat changelog.md
+
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1.14.0
         with:
@@ -219,6 +241,7 @@ jobs:
           name: ${{ needs.setVersionNumber.outputs.version_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: ${{ github.event.inputs.createRelease != 'true' }}
+          bodyFile: changelog.md
             
   # itch.io uploader
   checkItchIO:

--- a/release_notes_generator/.gitignore
+++ b/release_notes_generator/.gitignore
@@ -1,0 +1,32 @@
+*.swp
+*.*~
+project.lock.json
+.DS_Store
+*.pyc
+
+# Visual Studio Code
+.vscode
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+build/
+bld/
+[Bb]in/
+[Oo]bj/
+msbuild.log
+msbuild.err
+msbuild.wrn
+
+# Visual Studio 2015
+.vs/

--- a/release_notes_generator/ReleaseNotesGenerator.Tests/ReleaseNoteGeneratorTest.cs
+++ b/release_notes_generator/ReleaseNotesGenerator.Tests/ReleaseNoteGeneratorTest.cs
@@ -1,0 +1,55 @@
+using System;
+using NUnit.Framework;
+
+namespace ReleaseNotesGenerator.Tests;
+
+[TestFixture]
+[TestOf(typeof(ReleaseNoteGenerator))]
+public class ReleaseNoteGeneratorTest
+{
+    [TestCase(
+"""
+chore(docs): Update auto-generated docs
+feat!(Investigation): Split `&UNLOCK_CHOICE` into `&UNLOCK_MOVE_CHOICE` and `&UNLOCK_TALK_CHOICE`
+feat(Investigation): Track already examined choice options
+feat: Ability to pick up Details
+fix(Investigation): Only show Details as already examined, if they were found in the same scene
+fix!: Properly link mouse cursors
+""",
+
+"""
+# New Features
+
+## Investigation
+
+- **BREAKING CHANGE**: Split `&UNLOCK_CHOICE` into `&UNLOCK_MOVE_CHOICE` and `&UNLOCK_TALK_CHOICE`
+- Track already examined choice options
+
+## Other
+
+- Ability to pick up Details
+
+# Bug Fixes
+
+## Investigation
+
+- Only show Details as already examined, if they were found in the same scene
+
+## Other
+
+- **BREAKING CHANGE**: Properly link mouse cursors
+""")]
+    [TestCase(
+        "chore(docs): Update auto-generated docs",
+        "No player-facing changes since last prerelease"
+    )]
+    [TestCase(
+        "",
+        "No player-facing changes since last prerelease"
+    )]
+    public void ConventionalCommitsGenerateMarkdown(string commits, string markdown)
+    {
+        Assert.That(ReleaseNoteGenerator.ParseLines(commits.Split(Environment.NewLine)), Is.EqualTo(markdown));
+    }
+    
+}

--- a/release_notes_generator/ReleaseNotesGenerator.Tests/ReleaseNotesGenerator.Tests.csproj
+++ b/release_notes_generator/ReleaseNotesGenerator.Tests/ReleaseNotesGenerator.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReleaseNotesGenerator\ReleaseNotesGenerator.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/release_notes_generator/ReleaseNotesGenerator.sln
+++ b/release_notes_generator/ReleaseNotesGenerator.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReleaseNotesGenerator", "ReleaseNotesGenerator\ReleaseNotesGenerator.csproj", "{941B0A55-9140-42C3-9289-BF53F4DB2CAD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReleaseNotesGenerator.Tests", "ReleaseNotesGenerator.Tests\ReleaseNotesGenerator.Tests.csproj", "{742480DA-D433-4CDE-B9AF-9EE37E67A26C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{941B0A55-9140-42C3-9289-BF53F4DB2CAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{941B0A55-9140-42C3-9289-BF53F4DB2CAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{941B0A55-9140-42C3-9289-BF53F4DB2CAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{941B0A55-9140-42C3-9289-BF53F4DB2CAD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{742480DA-D433-4CDE-B9AF-9EE37E67A26C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{742480DA-D433-4CDE-B9AF-9EE37E67A26C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{742480DA-D433-4CDE-B9AF-9EE37E67A26C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{742480DA-D433-4CDE-B9AF-9EE37E67A26C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/release_notes_generator/ReleaseNotesGenerator/Program.cs
+++ b/release_notes_generator/ReleaseNotesGenerator/Program.cs
@@ -1,0 +1,92 @@
+﻿using System.Text;
+using System.Text.RegularExpressions;
+using Octokit;
+
+namespace ReleaseNotesGenerator;
+
+public partial class ReleaseNoteGenerator
+{
+    private const string RepositoryOwner = "Studio-Lovelies";
+    private const string RepositoryName = "GG-JointJustice-Unity";
+    
+    public static async Task Main()
+    {
+        var github = new GitHubClient(new ProductHeaderValue("StudioLoveliesReleaseNoteGenerator"))
+        {
+            Credentials = new Credentials(Environment.GetEnvironmentVariable("GITHUB_TOKEN"), AuthenticationType.Bearer)
+        };
+
+        var gitTagOfLastGitHubPrerelease = (await github.Repository.Release.GetAll(RepositoryOwner, RepositoryName))
+            .Where(release => release.Prerelease)
+            .OrderByDescending(release => release.CreatedAt)
+            .First();
+        var gitCommitHashOfLastGitHubPrerelease = (await github.Repository.Commit.Get(RepositoryOwner, RepositoryName, gitTagOfLastGitHubPrerelease.TagName));
+        var currentCommitOnDevelop = await github.Repository.Commit.Get(RepositoryOwner, RepositoryName, "develop");
+
+        var commitsSinceLastPrerelease = (await github.Repository.Commit.Compare(RepositoryOwner, RepositoryName, gitCommitHashOfLastGitHubPrerelease.Sha, currentCommitOnDevelop.Sha)).Commits;
+
+        var commitMessages = commitsSinceLastPrerelease.Select(commit => commit.Commit.Message);
+        await File.WriteAllTextAsync("changelog.md", ParseLines(commitMessages));
+    }
+
+    public static string ParseLines(IEnumerable<string> commitMessages)
+    {
+        var conventionalCommits = commitMessages.Select(commitMessage => ConventionalCommit().Match(commitMessage)).Where(match => match.Success).ToList();
+        
+        if (conventionalCommits.Count == 0)
+        {
+            return "No player-facing changes since last prerelease";
+        }
+        
+        var commitsByTypeAndScopeWithBreakingChangePrefix = conventionalCommits
+            .GroupBy(match => match.Groups["type"].Value)
+            .ToDictionary(typeGroup => typeGroup.Key, typeGroup => typeGroup
+                .GroupBy(match => match.Groups["scope"].Value)
+                .ToDictionary(scopeGroup => scopeGroup.Key, scopeGroup => scopeGroup
+                    .Select(match => match.Groups["breaking"].Value == "!" || match.Groups["breaking2"].Value == "!" ? "**BREAKING CHANGE**: " + match.Groups["message"].Value : match.Groups["message"].Value)
+                    .ToList()
+                )
+            );
+
+        var markdownBuilder = new StringBuilder();
+        foreach (var (type, scopes) in commitsByTypeAndScopeWithBreakingChangePrefix)
+        {
+            var displayType = type switch
+            {
+                "feat" => "New Features",
+                "fix" => "Bug Fixes",
+                _ => throw new NotSupportedException("Only `feat` and `fix` are supported")
+            };
+            markdownBuilder.AppendLine($"# {displayType}{Environment.NewLine}");
+            foreach (var (scope, messages) in scopes.Where(scope => scope.Key != ""))
+            {
+                markdownBuilder.AppendLine($"## {scope}{Environment.NewLine}");
+                foreach (var message in messages)
+                {
+                    markdownBuilder.AppendLine($"- {message}");
+                }
+            }
+
+            var otherCommits = scopes.Where(scope => scope.Key == "").SelectMany(scope => scope.Value).ToList();
+            if (otherCommits.Count == 0)
+            {
+                markdownBuilder.AppendLine();
+                continue;
+            }
+
+            markdownBuilder.AppendLine();
+            markdownBuilder.AppendLine($"## Other{Environment.NewLine}");
+            foreach (var message in otherCommits)
+            {
+                markdownBuilder.AppendLine($"- {message}");
+            }
+
+            markdownBuilder.AppendLine();
+        }
+
+        return markdownBuilder.ToString().Trim();
+    }
+
+    [GeneratedRegex(@"(?<type>feat|fix)(?<breaking2>!)?(?:\((?<scope>.*)\))?(?<breaking>!)?: (?<message>.*)")]
+    private static partial Regex ConventionalCommit();
+}

--- a/release_notes_generator/ReleaseNotesGenerator/ReleaseNotesGenerator.csproj
+++ b/release_notes_generator/ReleaseNotesGenerator/ReleaseNotesGenerator.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Octokit" Version="13.0.1" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
This PR updates the prerelease GitHub Action to generate a proper changelog.

## Before/after screenshots and/or animated gif
### Before
Even though [13 commits](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/compare/v0.0.8-runtimeedit.8...v2024.09.21-380) were pushed between releases, the GitHub Release has no description, only showing the latest commit, that is irrelevant for any non-programmer downloading the build:
![image](https://github.com/user-attachments/assets/a01b94ee-9162-47f3-8bb0-9a5285d3d495)
### After
Pushing 6 commits with the messages…
```
chore(docs): Update auto-generated docs
feat!(Investigation): Split `&UNLOCK_CHOICE` into `&UNLOCK_MOVE_CHOICE` and `&UNLOCK_TALK_CHOICE`
feat(Investigation): Track already examined choice options
feat: Ability to pick up Details
fix(Investigation): Only show Details as already examined, if they were found in the same scene
fix!: Properly link mouse cursors
```
…results in a description of …
> # New Features
> 
> ## Investigation
> 
> - **BREAKING CHANGE**: Split `&UNLOCK_CHOICE` into `&UNLOCK_MOVE_CHOICE` and `&UNLOCK_TALK_CHOICE`
> - Track already examined choice options
> 
> ## Other
> 
> - Ability to pick up Details
> 
> # Bug Fixes
> 
> ## Investigation
> 
> - Only show Details as already examined, if they were found in the same scene
> 
> ## Other
> 
> - **BREAKING CHANGE**: Properly link mouse cursors

## Testing instructions
As with any of our GitHub Actions, testing is only really possible after integration.  

## Reviewer notes
As this is a bunch of new code, a bit of context on what got added and where:

I've added [`release_notes_generator/ReleaseNotesGenerator`, a C# console application](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/tree/users/vm/release-notes/release_notes_generator) that only requires [`GITHUB_TOKEN` to be an environment variable](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/blob/users/vm/release-notes/release_notes_generator/ReleaseNotesGenerator/Program.cs#L16) with a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with access to this repository as value.

Building and running `release_notes_generator/ReleaseNotesGenerator` will generate a `changelog.md` with the format shown in the `before/after` section.

Running the generator and using the resulting markdown file as the description was added [to the prerelease automation](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/pull/486/files#diff-48c0ee97c53013d18d6bbae44648f7fab9af2e0bf5b0dc1ca761e18ec5c478f2).

The console app uses GitHub's official C# API client to fetch the current `develop` and last pre-release commit and finds all new commits:

https://github.com/Studio-Lovelies/GG-JointJustice-Unity/blob/5c044d775a8210c6b9eff3958c28032aba82ad71/release_notes_generator/ReleaseNotesGenerator/Program.cs#L19-L26

The script adds all commits that match [the Conventional Commit syntax](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/pull/486/files#diff-8a10fc5f8e6b5ffef6169d09cf613203561be7163c90ef01f6e9d101eae33990R90) and are of type `feat` and `fix` to the changelog. If a scope is specified (like `Investigation` in my example), commits are grouped by it.

Other commits are not added to the changelog.

If no commits match, the changelog states `No player-facing changes since last prerelease` ([source](https://github.com/Studio-Lovelies/GG-JointJustice-Unity/pull/486/files#diff-8a10fc5f8e6b5ffef6169d09cf613203561be7163c90ef01f6e9d101eae33990R38))

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[ ]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->
