### PR TITLE
Adds `Back` button as last option to all `Talk` and `Move` choices to return to investigation main menu

### DIFF
--- a/unity-ggjj/Assets/Scripts/GameState/InvestigationState.cs
+++ b/unity-ggjj/Assets/Scripts/GameState/InvestigationState.cs
@@ -90,7 +90,11 @@ public class InvestigationState : MonoBehaviour, IInvestigationState
         
         // Open choice menu
         _investigationMainMenuOpener.CloseMenu();
-        _investigationTalkMenu.Initialise(_talkOptions);
+        _investigationTalkMenu.Initialise(_talkOptions, () =>
+        {
+            _investigationTalkMenu.DeactivateChoiceMenu();
+            OpenWithChoices(_talkOptions, _moveOptions);
+        });
         var selectableAndLabel = _investigationTalkMenu.GetComponentsInChildren<MenuItem>().ToList();
 
         foreach (var menuItem in selectableAndLabel)
@@ -98,6 +102,11 @@ public class InvestigationState : MonoBehaviour, IInvestigationState
             menuItem.transform.Find("AlreadyExamined").gameObject.SetActive(_examinedTalkChoices.Contains(_narrativeGameState.SceneController.ActiveSceneName + "_" + menuItem.Text));
             menuItem.GetComponent<Button>().onClick.AddListener(() =>
             {
+                if (menuItem.Text == ChoiceMenu.BACK_BUTTON_LABEL)
+                {
+                    return;
+                }
+                
                 _examinedTalkChoices.Add(_narrativeGameState.SceneController.ActiveSceneName + "_" + menuItem.Text);
             });
         }
@@ -107,7 +116,12 @@ public class InvestigationState : MonoBehaviour, IInvestigationState
     {
         _investigationMainMenuOpener.CloseMenu();
         _investigationMoveMenu.transform.parent.gameObject.SetActive(true);
-        _investigationMoveMenu.Initialise(_moveOptions);
+        _investigationMoveMenu.Initialise(_moveOptions, () =>
+        {
+            _investigationMoveMenu.DeactivateChoiceMenu();
+            _investigationMoveMenu.transform.parent.gameObject.SetActive(false);
+            OpenWithChoices(_talkOptions, _moveOptions);
+        });
 
         var selectableAndLabel = _investigationMoveMenu.GetComponentsInChildren<MenuItem>().ToList();
 
@@ -116,11 +130,21 @@ public class InvestigationState : MonoBehaviour, IInvestigationState
             menuItem.transform.Find("AlreadyExamined").gameObject.SetActive(_examinedMoveChoices.Contains(_narrativeGameState.SceneController.ActiveSceneName + "_" + menuItem.Text));
             menuItem.GetComponent<Button>().onClick.AddListener(() =>
             {
+                if (menuItem.Text == ChoiceMenu.BACK_BUTTON_LABEL)
+                {
+                    return;
+                }
+                
+                _examinedMoveChoices.Add(_narrativeGameState.SceneController.ActiveSceneName + "_" + menuItem.Text);
                 _investigationMoveMenu.transform.parent.gameObject.SetActive(false);
             });
             menuItem.OnItemSelect.AddListener(() =>
             {
-                _examinedMoveChoices.Add(_narrativeGameState.SceneController.ActiveSceneName + "_" + menuItem.Text);
+                if (menuItem.Text == ChoiceMenu.BACK_BUTTON_LABEL)
+                {
+                    return;
+                }
+                
                 var bgScene = _moveOptions
                     .First(choice => choice.text == menuItem.Text)
                     .tags

--- a/unity-ggjj/Assets/Scripts/Menu/ChoiceMenu/ChoiceMenu.cs
+++ b/unity-ggjj/Assets/Scripts/Menu/ChoiceMenu/ChoiceMenu.cs
@@ -1,9 +1,8 @@
-using System.Collections;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Ink.Runtime;
 using UnityEngine;
-using UnityEngine.Serialization;
 using UnityEngine.UI;
 
 [RequireComponent(typeof(Menu))]
@@ -20,14 +19,16 @@ public class ChoiceMenu : MonoBehaviour, IChoiceMenu
     [Tooltip("Drag a menu opener component here.")]
     [SerializeField] private MenuOpener _menuOpener;
 
+    public const string BACK_BUTTON_LABEL = "Back";
+
     /// <summary>
     /// Creates a choice menu using a choice list.
     /// Opens the menu, instantiates the correct number of buttons and
     /// assigns their text and onClick events.
     /// </summary>
     /// <param name="choiceList">The list of choices in the choice menu.</param>
-    /// <param name="flags">Properties of the choice menu</param>
-    public void Initialise(List<Choice> choiceList)
+    /// <param name="onBackButtonClick">If the menu should have the option to go back, supply logic that should be executed when the back button is clicked.</param>
+    public void Initialise(List<Choice> choiceList, Action onBackButtonClick)
     {
         if (gameObject.activeInHierarchy)
         {
@@ -62,6 +63,16 @@ public class ChoiceMenu : MonoBehaviour, IChoiceMenu
             }
             menuItem.Text = choice.text;
             ((Button)menuItem.Selectable).onClick.AddListener(() => OnChoiceClicked(choice.index));
+        }
+        
+        if (onBackButtonClick != null)
+        {
+            var menuItem = Instantiate(_choiceMenuItem, transform);
+            menuItem.Text = BACK_BUTTON_LABEL;
+            ((Button)menuItem.Selectable).onClick.AddListener(() =>
+            {
+                onBackButtonClick();
+            });
         }
     }
 

--- a/unity-ggjj/Assets/Scripts/Menu/ChoiceMenu/IChoiceMenu.cs
+++ b/unity-ggjj/Assets/Scripts/Menu/ChoiceMenu/IChoiceMenu.cs
@@ -1,7 +1,8 @@
+using System;
 using System.Collections.Generic;
 using Ink.Runtime;
 
 public interface IChoiceMenu
 {
-    void Initialise(List<Choice> storyCurrentChoices);
+    void Initialise(List<Choice> storyCurrentChoices, Action onBackButtonClick);
 }

--- a/unity-ggjj/Assets/Scripts/NarrativeScript/NarrativeScriptPlayer/NarrativeScriptPlayer.cs
+++ b/unity-ggjj/Assets/Scripts/NarrativeScript/NarrativeScriptPlayer/NarrativeScriptPlayer.cs
@@ -178,7 +178,7 @@ public class NarrativeScriptPlayer : INarrativeScriptPlayer
                 _narrativeGameState.InvestigationState.OpenWithChoices(talkOptions, moveOptions);
                 break;
             case GameMode.Dialogue:
-                _narrativeGameState.ChoiceMenu.Initialise(Story.currentChoices);
+                _narrativeGameState.ChoiceMenu.Initialise(Story.currentChoices, null);
                 break;
             case GameMode.CrossExamination:
                 HandleChoice(0);

--- a/unity-ggjj/Assets/Tests/EditModeTests/Suites/Core/StoryPlayerTests.cs
+++ b/unity-ggjj/Assets/Tests/EditModeTests/Suites/Core/StoryPlayerTests.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using Ink;
 using Ink.Runtime;
 using Moq;
@@ -73,7 +73,7 @@ namespace Tests.EditModeTests.Suites
             const string TEST_SCRIPT = "+ [1]\n-> DONE\n+ [2]\n-> DONE";
             _narrativeScriptPlayer.ActiveNarrativeScript = CreateNarrativeScript(TEST_SCRIPT);
 
-            _narrativeGameStateMock.Setup(mock => mock.ChoiceMenu.Initialise(It.IsAny<List<Choice>>())).Verifiable();
+            _narrativeGameStateMock.Setup(mock => mock.ChoiceMenu.Initialise(It.IsAny<List<Choice>>(), It.IsAny<Action>())).Verifiable();
             _narrativeScriptPlayer.Continue();
             _narrativeGameStateMock.Verify();
         }
@@ -86,7 +86,7 @@ namespace Tests.EditModeTests.Suites
 
             _narrativeScriptPlayer.GameMode = GameMode.CrossExamination;
             bool callback = false;
-            _narrativeGameStateMock.Setup(mock => mock.ChoiceMenu.Initialise(It.IsAny<List<Choice>>())).Callback(() => callback = true);
+            _narrativeGameStateMock.Setup(mock => mock.ChoiceMenu.Initialise(It.IsAny<List<Choice>>(), It.IsAny<Action>())).Callback(() => callback = true);
             _narrativeScriptPlayer.Continue();
             Assert.IsFalse(callback);
         }

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Suites/Scripts/InvestigationState/InvestigationStateKeyboardTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Suites/Scripts/InvestigationState/InvestigationStateKeyboardTests.cs
@@ -70,7 +70,7 @@ namespace Tests.PlayModeTests.Suites.Scripts.InvestigationState
             Assert.False(InvestigationMainMenu.isActiveAndEnabled);
             Assert.True(InvestigationMoveMenu.isActiveAndEnabled);
             Assert.True(InvestigateMoveContainer.activeInHierarchy);
-            Assert.AreEqual(1, InvestigationMoveMenu.GetComponentsInChildren<MenuItem>().Length);
+            Assert.AreEqual(2, InvestigationMoveMenu.GetComponentsInChildren<MenuItem>().Length);
             yield return PressX();
             
             Assert.False(InvestigationMoveMenu.isActiveAndEnabled);
@@ -101,7 +101,7 @@ namespace Tests.PlayModeTests.Suites.Scripts.InvestigationState
             // Select talk option 1
             Assert.False(InvestigationMainMenu.isActiveAndEnabled);
             Assert.True(InvestigationTalkMenu.isActiveAndEnabled);
-            Assert.AreEqual(2, InvestigationTalkMenu.GetComponentsInChildren<MenuItem>().Length);
+            Assert.AreEqual(3, InvestigationTalkMenu.GetComponentsInChildren<MenuItem>().Length);
             yield return PressX();
             
             Assert.False(InvestigationTalkMenu.isActiveAndEnabled);
@@ -117,7 +117,7 @@ namespace Tests.PlayModeTests.Suites.Scripts.InvestigationState
             
             Assert.False(InvestigationMainMenu.isActiveAndEnabled);
             Assert.True(InvestigationTalkMenu.isActiveAndEnabled);
-            Assert.AreEqual(2, InvestigationTalkMenu.GetComponentsInChildren<MenuItem>().Length);
+            Assert.AreEqual(3, InvestigationTalkMenu.GetComponentsInChildren<MenuItem>().Length);
             Assert.AreEqual(1, InvestigationTalkMenu.GetComponentsInChildren<MenuItem>().Count(item => item.transform.Find("AlreadyExamined").gameObject.activeSelf));
             yield return PressDown();
             yield return PressX();
@@ -135,7 +135,7 @@ namespace Tests.PlayModeTests.Suites.Scripts.InvestigationState
             
             Assert.False(InvestigationMainMenu.isActiveAndEnabled);
             Assert.True(InvestigationTalkMenu.isActiveAndEnabled);
-            Assert.AreEqual(3, InvestigationTalkMenu.GetComponentsInChildren<MenuItem>().Length);
+            Assert.AreEqual(4, InvestigationTalkMenu.GetComponentsInChildren<MenuItem>().Length);
             Assert.AreEqual(2, InvestigationTalkMenu.GetComponentsInChildren<MenuItem>().Count(item => item.transform.Find("AlreadyExamined").gameObject.activeSelf));
             yield return PressDown();
             yield return PressDown();
@@ -156,7 +156,7 @@ namespace Tests.PlayModeTests.Suites.Scripts.InvestigationState
             Assert.False(InvestigationMainMenu.isActiveAndEnabled);
             Assert.True(InvestigationMoveMenu.isActiveAndEnabled);
             Assert.True(InvestigateMoveContainer.activeInHierarchy);
-            Assert.AreEqual(2, InvestigationMoveMenu.GetComponentsInChildren<MenuItem>().Length);
+            Assert.AreEqual(3, InvestigationMoveMenu.GetComponentsInChildren<MenuItem>().Length);
             Assert.AreEqual(1, InvestigationMoveMenu.GetComponentsInChildren<MenuItem>().Count(item => item.transform.Find("AlreadyExamined").gameObject.activeSelf));
             yield return PressDown();
             yield return PressX();
@@ -183,6 +183,84 @@ namespace Tests.PlayModeTests.Suites.Scripts.InvestigationState
             
             yield return PressEsc();
             Assert.True(InvestigationMainMenu.isActiveAndEnabled);
+        }
+        
+        [UnityTest]
+        public IEnumerator InvestigationTalkCanReturnToMainMenuUsingBackButton()
+        {
+            Assert.False(InvestigationMainMenu.isActiveAndEnabled);
+            yield return PressX();
+            
+            // Select Talk button
+            Assert.True(InvestigationMainMenu.isActiveAndEnabled);
+            yield return PressRight();
+            yield return PressX();
+            
+            // #initial dialogue plays
+            Assert.False(InvestigationMainMenu.isActiveAndEnabled);
+            Assert.False(InvestigationTalkMenu.isActiveAndEnabled);
+            while (!InvestigationMainMenu.isActiveAndEnabled)
+            {
+                yield return StoryProgresser.ProgressStory();
+            }
+            
+            // Select talk again
+            Assert.True(InvestigationMainMenu.isActiveAndEnabled);
+            yield return PressRight();
+            yield return PressX();
+            
+            // Select back button
+            Assert.False(InvestigationMainMenu.isActiveAndEnabled);
+            yield return PressDown();
+            yield return PressDown();
+            yield return PressDown();
+            yield return PressX();  
+            
+            Assert.True(InvestigationMainMenu.isActiveAndEnabled);
+            
+            // Select Talk button again and verify back button isn't checked
+            yield return PressRight();
+            yield return PressX();
+            
+            Assert.False(InvestigationMainMenu.isActiveAndEnabled);
+            Assert.True(InvestigationTalkMenu.isActiveAndEnabled);
+            Assert.AreEqual(3, InvestigationTalkMenu.GetComponentsInChildren<MenuItem>().Length);
+            Assert.AreEqual(0, InvestigationTalkMenu.GetComponentsInChildren<MenuItem>().Count(item => item.transform.Find("AlreadyExamined").gameObject.activeSelf));
+        }
+        
+        [UnityTest]
+        public IEnumerator InvestigationMoveCanReturnToMainMenuUsingBackButton()
+        {
+            Assert.False(InvestigationMainMenu.isActiveAndEnabled);
+            yield return PressX();
+            
+            // Select Move button
+            Assert.True(InvestigationMainMenu.isActiveAndEnabled);
+            yield return PressRight();
+            yield return PressRight();
+            yield return PressX();
+            
+            Assert.False(InvestigationMainMenu.isActiveAndEnabled);
+            Assert.True(InvestigationMoveMenu.isActiveAndEnabled);
+            Assert.True(InvestigateMoveContainer.activeInHierarchy);
+            Assert.AreEqual(2, InvestigationMoveMenu.GetComponentsInChildren<MenuItem>().Length);
+            Assert.AreEqual(0, InvestigationMoveMenu.GetComponentsInChildren<MenuItem>().Count(item => item.transform.Find("AlreadyExamined").gameObject.activeSelf));
+            
+            // Select back button
+            yield return PressDown();
+            yield return PressX();
+            
+            Assert.True(InvestigationMainMenu.isActiveAndEnabled);
+            
+            // Select Move button again and verify back button isn't checked
+            yield return PressRight();
+            yield return PressRight();
+            yield return PressX();
+            
+            Assert.False(InvestigationMainMenu.isActiveAndEnabled);
+            Assert.True(InvestigationMoveMenu.isActiveAndEnabled);
+            Assert.AreEqual(2, InvestigationMoveMenu.GetComponentsInChildren<MenuItem>().Length);
+            Assert.AreEqual(0, InvestigationMoveMenu.GetComponentsInChildren<MenuItem>().Count(item => item.transform.Find("AlreadyExamined").gameObject.activeSelf));
         }
         
         private IEnumerator PressX()


### PR DESCRIPTION
## Summary
The game currently forces players to make a choice when selecting `Talk` or `Move` inside the investigation main menu. This PR adds a back button to both sub-menus, without having to add it in the ink script. 

Game Design currently sees no scenario in which we want to force the player to make a choice in the sub-menus, hence the request to add it automatically via C#.

## Before/after screenshots and/or animated gif
```ink
&HIDE_TEXTBOX
+ [Introduction #Talk #Initial]
    -> Initial
+ [So where's your Dad? #Talk]
    -> Dad
+ [Does it smell like Updog in here? #Talk]
    -> Updog
+ [So about Rachel #Talk #Locked]
    -> Rachel
+ [Kitchen #Move #TMPHWideShot]
    -> Kitchen
+ [Connecticut #Move #Locked #TMPHProsecution]
    -> Connecticut
```
### Before
![image](https://github.com/user-attachments/assets/4d28007b-5069-46e3-88f1-02c53a05edef)

### After
![image](https://github.com/user-attachments/assets/e23f8c13-feaf-4ca8-b021-cf2e7dd702ac)

## Testing instructions
1. Open the `Game` scene
2. Set the `GameStarter` to `InvestigationUI`
3. Select `Talk`
4. Go back to the main menu by selecting `Back`
5. Select `Move`
6. Go back to the main menu by selecting `Back`

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[x]` Has associated resource: 
  #456
