### PR TITLE
Hide unestablished scene preview images inside investigation move sub-menu

### DIFF
--- a/unity-ggjj/Assets/Images/BackgroundsAndForegrounds/UnestablishedScene.png
+++ b/unity-ggjj/Assets/Images/BackgroundsAndForegrounds/UnestablishedScene.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93a97b9c74ddb6381aa47bd8a12040f8449c4d9ddd75da21caea184e36e5a789
+size 202

--- a/unity-ggjj/Assets/Images/BackgroundsAndForegrounds/UnestablishedScene.png.meta
+++ b/unity-ggjj/Assets/Images/BackgroundsAndForegrounds/UnestablishedScene.png.meta
@@ -1,0 +1,127 @@
+fileFormatVersion: 2
+guid: cbc4be33b343c4c71b9d485d9ba55181
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 16384
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-ggjj/Assets/Scenes/Game.unity
+++ b/unity-ggjj/Assets/Scenes/Game.unity
@@ -13351,7 +13351,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _gameStartSettings: {fileID: 11400000, guid: cd99fbc599aa449fb855f6a61725a529, type: 2}
-  _debugNarrativeScriptTextAsset: {fileID: 4900000, guid: 9fd28bbf277094e0d9f0a8f09fd4fb42, type: 3}
+  _debugNarrativeScriptTextAsset: {fileID: 0}
 --- !u!114 &8371940055574374657
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/unity-ggjj/Assets/Scenes/Game.unity
+++ b/unity-ggjj/Assets/Scenes/Game.unity
@@ -13351,7 +13351,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _gameStartSettings: {fileID: 11400000, guid: cd99fbc599aa449fb855f6a61725a529, type: 2}
-  _debugNarrativeScriptTextAsset: {fileID: 0}
+  _debugNarrativeScriptTextAsset: {fileID: 4900000, guid: 9fd28bbf277094e0d9f0a8f09fd4fb42, type: 3}
 --- !u!114 &8371940055574374657
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -13371,6 +13371,7 @@ MonoBehaviour:
   _inputManager: {fileID: 4120714960866268583}
   _gameInputModule: {fileID: 342284811}
   _investigationInputModule: {fileID: 1147734101}
+  _unestablishedSceneBackground: {fileID: 2800000, guid: cbc4be33b343c4c71b9d485d9ba55181, type: 3}
   _examinationNoEvidence: {fileID: 2800000, guid: 3b16fa953bff748cc967bb2242475417, type: 3}
   _examinationNewEvidence: {fileID: 2800000, guid: df40409b9a2144ab283894d9c2a0db76, type: 3}
   _examinationKnownEvidence: {fileID: 2800000, guid: 6ca44d6afef844a27a9e66de26fdd092, type: 3}

--- a/unity-ggjj/Assets/Scripts/GameState/InvestigationState.cs
+++ b/unity-ggjj/Assets/Scripts/GameState/InvestigationState.cs
@@ -6,6 +6,7 @@ using Ink.Runtime;
 using Input;
 using UnityEngine;
 using UnityEngine.InputSystem;
+using UnityEngine.Serialization;
 using UnityEngine.UI;
 
 public class InvestigationState : MonoBehaviour, IInvestigationState
@@ -112,6 +113,9 @@ public class InvestigationState : MonoBehaviour, IInvestigationState
         }
     }
 
+    [FormerlySerializedAs("_unknownLocationBackground")]
+    [Header("Move")]
+    [SerializeField] private Texture2D _unestablishedSceneBackground;
     public void OpenMoveMenu()
     {
         _investigationMainMenuOpener.CloseMenu();
@@ -142,6 +146,13 @@ public class InvestigationState : MonoBehaviour, IInvestigationState
             {
                 if (menuItem.Text == ChoiceMenu.BACK_BUTTON_LABEL)
                 {
+                    return;
+                }
+                
+                // if unexamined, show _unestablishedSceneBackground
+                if (!_examinedMoveChoices.Contains(_narrativeGameState.SceneController.ActiveSceneName + "_" + menuItem.Text))
+                {
+                    _investigationMoveMenu.transform.parent.Find("SceneImage").GetComponent<Image>().sprite = Sprite.Create(_unestablishedSceneBackground, new Rect(0, 0, _unestablishedSceneBackground.width, _unestablishedSceneBackground.height), new Vector2(0.5f, 0.5f));
                     return;
                 }
                 

--- a/unity-ggjj/Assets/Tests/PlayModeTests/Suites/Scripts/InvestigationState/InvestigationStateKeyboardTests.cs
+++ b/unity-ggjj/Assets/Tests/PlayModeTests/Suites/Scripts/InvestigationState/InvestigationStateKeyboardTests.cs
@@ -54,7 +54,7 @@ namespace Tests.PlayModeTests.Suites.Scripts.InvestigationState
         }
         
         [UnityTest]
-        public IEnumerator InvestigationMenuCanUnlockAndMarkTalkOptions()
+        public IEnumerator InvestigationMenuCanUnlockAndMarkChoices()
         {
             var currentScriptName = NarrativeScriptPlayerComponent.NarrativeScriptPlayer.ActiveNarrativeScript.Script.name;
             
@@ -71,6 +71,10 @@ namespace Tests.PlayModeTests.Suites.Scripts.InvestigationState
             Assert.True(InvestigationMoveMenu.isActiveAndEnabled);
             Assert.True(InvestigateMoveContainer.activeInHierarchy);
             Assert.AreEqual(2, InvestigationMoveMenu.GetComponentsInChildren<MenuItem>().Length);
+            
+            // store preview image as it should change after examining move option 1
+            var currentPreviewImageName = InvestigateMoveContainer.transform.Find("SceneImage").GetComponent<Image>().sprite.texture.name;
+            Assert.IsNotEmpty(currentPreviewImageName);
             yield return PressX();
             
             Assert.False(InvestigationMoveMenu.isActiveAndEnabled);
@@ -158,6 +162,12 @@ namespace Tests.PlayModeTests.Suites.Scripts.InvestigationState
             Assert.True(InvestigateMoveContainer.activeInHierarchy);
             Assert.AreEqual(3, InvestigationMoveMenu.GetComponentsInChildren<MenuItem>().Length);
             Assert.AreEqual(1, InvestigationMoveMenu.GetComponentsInChildren<MenuItem>().Count(item => item.transform.Find("AlreadyExamined").gameObject.activeSelf));
+            
+            // Verfiy that the preview image has changed
+            var newPreviewImageName = InvestigateMoveContainer.transform.Find("SceneImage").GetComponent<Image>().sprite.texture.name;
+            Assert.IsNotEmpty(newPreviewImageName);
+            Assert.AreNotEqual(currentPreviewImageName, newPreviewImageName);
+            
             yield return PressDown();
             yield return PressX();
             


### PR DESCRIPTION
## Summary
Currently, all move options have distinct preview images. To add suspense, these should be hidden until a player has chosen them at least once.

## Before/after screenshots and/or animated gif

### Before

https://github.com/user-attachments/assets/37d1ae22-8a5a-47cc-8b61-857c391e7874

### After

https://github.com/user-attachments/assets/e237cdd3-9864-4020-9f73-ab448006aad8

## Testing instructions
1. Open the `Game` scene
2. Set the `GameStarter` to `InvestigationUI`
3. Select `Move`
4. Notice the generic preview image
5. Select the only option besides `Back` and play through the dialogue
6. Select `Move` again
7. Notice the preview image showing a proper background

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[x]` Has associated resource: 
  - #456 
