### PR TITLE
Show actors when returning to investigation main menu

### DIFF
--- a/unity-ggjj/Assets/Scripts/GameState/InvestigationState.cs
+++ b/unity-ggjj/Assets/Scripts/GameState/InvestigationState.cs
@@ -198,6 +198,7 @@ public class InvestigationState : MonoBehaviour, IInvestigationState
             _narrativeGameState.AppearingDialogueController.TextBoxHidden = true;
             _examinedDetails.Add($"{_narrativeGameState.SceneController.ActiveSceneName}_{_hoveredDetail.NarrativeScriptToPlay.name}");
             _hoveredDetail.AttemptPickUp();
+            _narrativeGameState.ActorController.SetVisibility(true, null);
         }; 
     }
 
@@ -233,6 +234,7 @@ public class InvestigationState : MonoBehaviour, IInvestigationState
     public void QuitExamination()
     {
         Cursor.SetCursor(null, Vector2.zero, CursorMode.Auto);
+        _narrativeGameState.ActorController.SetVisibility(true, null);
         _investigationMainMenuOpener.OpenMenu();
     }
     #endregion


### PR DESCRIPTION
## Summary
Actors are hidden when pressing `Examine` and don't reappear after sub-stories complete or the user exits to the main menu.  
This PR makes Actors reappear, per request from Game Design.

## Before/after screenshots and/or animated gif

### Before

https://github.com/user-attachments/assets/d0fa7775-e065-4fe9-b333-8ba431ca635f

### After

https://github.com/user-attachments/assets/addffa21-27f0-4152-bc70-63006dff9c36

## Testing instructions
1. Open the `Game` scene
2. Set the `GameStarter` to `InvestigationUI`
3. Select `Examine`
4. Press `Esc`
5. Notice Dan reappearing
6. Select `Examine` again
7. Select the speaker on the right
8. Play through the speaker sub-story
9. Notice Dan reappearing

Play through the steps on `develop` and notice that Dan doesn't reappear

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[x]` Has associated resource: 
  - #456 
