### PR TITLE
Updates Ink package

### DIFF
--- a/unity-ggjj/Packages/manifest.json
+++ b/unity-ggjj/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.inklestudios.ink-unity-integration": "1.1.1",
+    "com.inkle.ink-unity-integration": "1.2.1",
     "com.unity.2d.animation": "9.0.3",
     "com.unity.2d.pixel-perfect": "5.0.3",
     "com.unity.2d.sprite": "1.0.0",
@@ -56,7 +56,7 @@
       "name": "OpenUPM",
       "url": "https://package.openupm.com",
       "scopes": [
-        "com.inklestudios.ink-unity-integration"
+        "com.inkle.ink-unity-integration"
       ]
     }
   ],

--- a/unity-ggjj/Packages/packages-lock.json
+++ b/unity-ggjj/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.inklestudios.ink-unity-integration": {
-      "version": "1.1.1",
+    "com.inkle.ink-unity-integration": {
+      "version": "1.2.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {},

--- a/unity-ggjj/ProjectSettings/PackageManagerSettings.asset
+++ b/unity-ggjj/ProjectSettings/PackageManagerSettings.asset
@@ -13,7 +13,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_EnablePreReleasePackages: 0
-  m_EnablePackageDependencies: 0
   m_AdvancedSettingsExpanded: 1
   m_ScopedRegistriesSettingsExpanded: 1
   m_SeeAllPackageVersions: 0
@@ -31,7 +30,7 @@ MonoBehaviour:
     m_Name: OpenUPM
     m_Url: https://package.openupm.com
     m_Scopes:
-    - com.inklestudios.ink-unity-integration
+    - com.inkle.ink-unity-integration
     m_IsDefault: 0
     m_Capabilities: 0
     m_ConfigSource: 4
@@ -40,6 +39,6 @@ MonoBehaviour:
   m_RegistryInfoDraft:
     m_Modified: 0
     m_ErrorMessage: 
-    m_UserModificationsInstanceId: -828
-    m_OriginalInstanceId: -832
+    m_UserModificationsInstanceId: -836
+    m_OriginalInstanceId: -838
   m_LoadAssets: 0


### PR DESCRIPTION
## Summary
Inkle recently changed their package name and released a few updates. This PR changes the package to the new name and updates it from `1.1.1` to `1.2.1`.

GitHub Actions Runs are flaky at the moment and some run failures seem to stem from the `compileTimeout` being ignored in batchMode:
1. Open https://github.com/Studio-Lovelies/GG-JointJustice-Unity/actions/runs/15085544932/job/42409223588?pr=513#step:9:1877
2. Select the cog icon at the top right and enable `Show timestamps`
  ![The context menu shown after clicking the cog icon](https://github.com/user-attachments/assets/5c932fc8-4db5-4a7b-88a7-42d4367848cf)
3. Notice the timeout at `Sat, 17 May 2025 14:51:08 GMT`, while the step was started at `Sat, 17 May 2025 14:48:17 GMT` (less than 3 minutes)

Before I open a bug report on their package, I want to see if updating to the latest version resolves it.

## Testing instructions
No gameplay changes; tests should succeed and the game can be completed as before.

## Additional information
<!--- Check any relevant boxes with "x" -->
- `[ ]` Changes UI
- `[ ]` Introduces new feature
- `[ ]` Removes existing feature
- `[ ]` Has associated resource: 
  <!--- Include any project card, github issue, etc. associated with this PR -->
